### PR TITLE
Add pristine handling on form

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -57,7 +57,9 @@
                                             if (navigator.serviceWorker.controller) {
                                                 // New update is available
                                                 console.info('SW: New update is available!');
-                                                const shouldUpdate = window.confirm('New update is available. Do you want to update now?');
+                                                // const shouldUpdate = window.confirm('New update is available. Do you want to update now?');
+                                                const shouldUpdate = true;
+                                                window.alert('New update is available.');
                                                 if (shouldUpdate) {
                                                     window.location.reload(true);
                                                 }

--- a/src/components/EntryForm/FigureInput.tsx
+++ b/src/components/EntryForm/FigureInput.tsx
@@ -177,7 +177,7 @@ function FigureInput(props: FigureInputProps) {
                     disabled={disabled}
                 />
                 <NumberInput
-                    label="Household Size"
+                    label="Household Size *"
                     name="householdSize"
                     value={value.householdSize}
                     onChange={onValueChange}

--- a/src/components/EntryForm/index.tsx
+++ b/src/components/EntryForm/index.tsx
@@ -187,7 +187,7 @@ const schema: Schema<PartialFormValues> = {
                         id: [idCondition],
                         district: [requiredStringCondition],
                         excerptIdu: [],
-                        householdSize: [],
+                        householdSize: [requiredCondition],
                         includeIdu: [],
                         isDisaggregated: [],
                         locationCamp: [],

--- a/src/components/EntryForm/index.tsx
+++ b/src/components/EntryForm/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useCallback } from 'react';
-import { useHistory, Prompt } from 'react-router-dom';
+import React, { useEffect, useCallback, useState } from 'react';
+import { Prompt, Redirect } from 'react-router-dom';
 import { _cs } from '@togglecorp/fujs';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -22,7 +22,7 @@ import NotificationContext from '#components/NotificationContext';
 import Section from '#components/Section';
 import EventForm from '#components/EventForm';
 import useForm, { useFormArray, createSubmitHandler } from '#utils/form';
-import { ObjectError, transformToFormError } from '#utils/errorTransform';
+import { transformToFormError } from '#utils/errorTransform';
 import type { Schema, Error } from '#utils/schema';
 import useModalState from '#hooks/useModalState';
 import {
@@ -342,7 +342,8 @@ function EntryForm(props: EntryFormProps) {
     const urlProcessed = !!preview;
     const attachmentProcessed = !!attachment;
     const processed = attachmentProcessed || urlProcessed;
-    const browserHistory = useHistory();
+
+    const [redirectId, setRedirectId] = useState<string | undefined>();
 
     const {
         pristine,
@@ -410,9 +411,9 @@ function EntryForm(props: EntryFormProps) {
                 } else {
                     const newEntryId = createEntryRes?.result?.id;
                     if (newEntryId) {
-                        onPristineSet(true);
                         notify({ children: 'New entry created successfully!' });
-                        browserHistory.replace(`/entries/${newEntryId}/`);
+                        onPristineSet(true);
+                        setRedirectId(newEntryId);
                     }
                 }
             },
@@ -574,8 +575,13 @@ function EntryForm(props: EntryFormProps) {
         || !!error?.fields?.event;
     const reviewErrored = !!error?.fields?.reviewers;
 
-    // FIXME: use this
-    console.warn(detailsTabErrored, analysisTabErrored, reviewErrored);
+    if (redirectId) {
+        return (
+            <Redirect
+                to={`/entries/${redirectId}/`}
+            />
+        );
+    }
 
     return (
         <form

--- a/src/components/EntryForm/index.tsx
+++ b/src/components/EntryForm/index.tsx
@@ -88,6 +88,10 @@ const CREATE_ENTRY = gql`
                 arrayErrors {
                     key
                     messages
+                    objectErrors {
+                        field
+                        messages
+                    }
                 }
                 field
                 messages

--- a/src/components/EntryForm/styles.css
+++ b/src/components/EntryForm/styles.css
@@ -110,6 +110,10 @@
                 flex-grow: 1;
                 padding: var(--spacing-medium);
             }
+
+            .errored {
+                color: var(--color-danger);
+            }
         }
 
         .details {

--- a/src/components/EventForm/index.tsx
+++ b/src/components/EventForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { listToMap } from '@togglecorp/fujs';
 import {
     TextInput,
@@ -197,7 +197,7 @@ const schema: Schema<FormType> = {
         id: [idCondition],
         actor: [],
         countries: [requiredCondition],
-        crisis: [requiredCondition],
+        crisis: [],
         disasterCategory: [],
         disasterSubCategory: [],
         disasterType: [],

--- a/src/utils/errorTransform.ts
+++ b/src/utils/errorTransform.ts
@@ -42,13 +42,18 @@ function transformObject(errors: ObjectError[] | undefined): BaseError | undefin
                 if (isDefined(error.messages)) {
                     return error.messages;
                 }
+                let objectErrors;
                 if (isDefined(error.objectErrors)) {
-                    return transformObject(error.objectErrors);
+                    objectErrors = transformObject(error.objectErrors);
                 }
+                let arrayErrors;
                 if (isDefined(error.arrayErrors)) {
-                    transformArray(error.arrayErrors);
+                    arrayErrors = transformArray(error.arrayErrors);
                 }
-                return undefined;
+                if (!objectErrors && !arrayErrors) {
+                    return undefined;
+                }
+                return { ...objectErrors, ...arrayErrors };
             },
         ),
     };

--- a/src/views/Entry/index.tsx
+++ b/src/views/Entry/index.tsx
@@ -122,6 +122,7 @@ function Entry(props: EntryProps) {
     const { entryId } = useParams<{ entryId: string }>();
     const entryFormRef = React.useRef<HTMLFormElement>(null);
     const [entryValue, setEntryValue] = React.useState<PartialFormValues>();
+    const [pristine, setPristine] = React.useState(true);
     const [submitPending, setSubmitPending] = React.useState<boolean>(false);
     const [attachment, setAttachment] = React.useState<Attachment | undefined>(undefined);
     const [preview, setPreview] = React.useState<Preview | undefined>(undefined);
@@ -190,7 +191,7 @@ function Entry(props: EntryProps) {
                             name={undefined}
                             variant="primary"
                             onClick={handleSubmitEntryButtonClick}
-                            disabled={(!attachment && !preview) || submitPending}
+                            disabled={(!attachment && !preview) || submitPending || pristine}
                         >
                             Submit entry
                         </Button>
@@ -204,6 +205,7 @@ function Entry(props: EntryProps) {
                             className={styles.entryForm}
                             elementRef={entryFormRef}
                             onChange={setEntryValue}
+                            onPristineChange={setPristine}
                             value={entryValue}
                             entryId={entryId}
                             attachment={attachment}

--- a/src/views/NewEntry/index.tsx
+++ b/src/views/NewEntry/index.tsx
@@ -25,6 +25,8 @@ function NewEntry(props: NewEntryProps) {
     const { className } = props;
     const entryFormRef = React.useRef<HTMLFormElement>(null);
     const [, setEntryValue] = React.useState<PartialFormValues>();
+    const [pristine, setPristine] = React.useState(true);
+    const [submitPending, setSubmitPending] = React.useState<boolean>(false);
     const [attachment, setAttachment] = React.useState<Attachment | undefined>(undefined);
     const [preview, setPreview] = React.useState<Preview | undefined>(undefined);
 
@@ -45,7 +47,7 @@ function NewEntry(props: NewEntryProps) {
                             name={undefined}
                             variant="primary"
                             onClick={handleSubmitEntryButtonClick}
-                            disabled={!attachment && !preview}
+                            disabled={(!attachment && !preview) || submitPending || pristine}
                         >
                             Submit Entry
                         </Button>
@@ -57,10 +59,12 @@ function NewEntry(props: NewEntryProps) {
                     className={styles.entryForm}
                     elementRef={entryFormRef}
                     onChange={setEntryValue}
+                    onPristineChange={setPristine}
                     attachment={attachment}
                     preview={preview}
                     onAttachmentChange={setAttachment}
                     onPreviewChange={setPreview}
+                    onRequestCallPendingChange={setSubmitPending}
                 />
                 <UrlPreview
                     className={styles.preview}


### PR DESCRIPTION
Depends on https://github.com/idmc-labs/helix-server/pull/44

- Disable entry form when it is pristine
- Add a prompt when leaving entry form tag if pristine
- Force user to always update to new version in service worker
- Re-use error transform on update and create entry
- Disable submit button on both create and edit entry page
- Show errors on tab if form errored
- Make crisis non-required