### PR TITLE
Fix pagination reset for all tables

### DIFF
--- a/src/components/tables/EntriesTable/EntriesFilter/index.tsx
+++ b/src/components/tables/EntriesTable/EntriesFilter/index.tsx
@@ -60,13 +60,13 @@ const STATUS_OPTIONS = gql`
 
 interface EntriesFilterProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<EntriesQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<EntriesQueryVariables>) => void;
 }
 
 function EntriesFilter(props: EntriesFilterProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
     } = props;
 
     const [
@@ -93,15 +93,15 @@ function EntriesFilter(props: EntriesFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/components/tables/EntriesTable/EntriesFilter/index.tsx
+++ b/src/components/tables/EntriesTable/EntriesFilter/index.tsx
@@ -60,15 +60,13 @@ const STATUS_OPTIONS = gql`
 
 interface EntriesFilterProps {
     className?: string;
-    setEntriesQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<EntriesQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<EntriesQueryVariables>) => void;
 }
 
 function EntriesFilter(props: EntriesFilterProps) {
     const {
         className,
-        setEntriesQueryFilters,
+        handleFilterSet,
     } = props;
 
     const [
@@ -95,15 +93,15 @@ function EntriesFilter(props: EntriesFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setEntriesQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setEntriesQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setEntriesQueryFilters(finalValues);
-    }, [onValueSet, setEntriesQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/components/tables/EntriesTable/index.tsx
+++ b/src/components/tables/EntriesTable/index.tsx
@@ -181,6 +181,11 @@ function EntriesTable(props: EntriesTableProps) {
         setEntriesQueryFilters,
     ] = useState<PurgeNull<EntriesQueryVariables>>();
 
+    const handleFilterSet = (value: PurgeNull<EntriesQueryVariables>) => {
+        setEntriesQueryFilters(value);
+        setPage(1);
+    };
+
     const entriesVariables = useMemo(
         (): EntriesQueryVariables => ({
             ordering,
@@ -367,7 +372,7 @@ function EntriesTable(props: EntriesTableProps) {
             contentClassName={styles.content}
             description={(
                 <EntriesFilter
-                    setEntriesQueryFilters={setEntriesQueryFilters}
+                    handleFilterSet={handleFilterSet}
                 />
             )}
             footerContent={!pagerDisabled && (

--- a/src/components/tables/EntriesTable/index.tsx
+++ b/src/components/tables/EntriesTable/index.tsx
@@ -181,10 +181,13 @@ function EntriesTable(props: EntriesTableProps) {
         setEntriesQueryFilters,
     ] = useState<PurgeNull<EntriesQueryVariables>>();
 
-    const handleFilterSet = (value: PurgeNull<EntriesQueryVariables>) => {
-        setEntriesQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<EntriesQueryVariables>) => {
+            setEntriesQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const entriesVariables = useMemo(
         (): EntriesQueryVariables => ({
@@ -372,7 +375,7 @@ function EntriesTable(props: EntriesTableProps) {
             contentClassName={styles.content}
             description={(
                 <EntriesFilter
-                    handleFilterSet={handleFilterSet}
+                    onFilterChange={onFilterChange}
                 />
             )}
             footerContent={!pagerDisabled && (

--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -150,10 +150,13 @@ function EventsTable(props: EventsProps) {
         crisisId ? { crisisByIds: [crisisId] } : undefined,
     );
 
-    const handleFilterSet = (value: PurgeNull<EventListQueryVariables>) => {
-        setEventQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<EventListQueryVariables>) => {
+            setEventQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const eventsVariables = useMemo(
         (): EventListQueryVariables => ({
@@ -407,7 +410,7 @@ function EventsTable(props: EventsProps) {
             description={(
                 <EventsFilter
                     crisisSelectionDisabled={!!crisisId}
-                    handleFilterSet={handleFilterSet}
+                    onFilterChange={onFilterChange}
                 />
             )}
         >

--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -150,6 +150,11 @@ function EventsTable(props: EventsProps) {
         crisisId ? { crisisByIds: [crisisId] } : undefined,
     );
 
+    const handleFilterSet = (value: PurgeNull<EventListQueryVariables>) => {
+        setEventQueryFilters(value);
+        setPage(1);
+    };
+
     const eventsVariables = useMemo(
         (): EventListQueryVariables => ({
             ordering,
@@ -402,7 +407,7 @@ function EventsTable(props: EventsProps) {
             description={(
                 <EventsFilter
                     crisisSelectionDisabled={!!crisisId}
-                    setEventQueryFilters={setEventQueryFilters}
+                    handleFilterSet={handleFilterSet}
                 />
             )}
         >

--- a/src/views/Admin/UserRoles/UserFilter/index.tsx
+++ b/src/views/Admin/UserRoles/UserFilter/index.tsx
@@ -63,7 +63,7 @@ const isActiveOptions = [
 
 interface UsersFilterProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<UserListQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<UserListQueryVariables>) => void;
 }
 
 /*
@@ -82,7 +82,7 @@ const labelSelector = (item: ActiveOption) => item.label;
 function UserFilter(props: UsersFilterProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
     } = props;
 
     const {
@@ -104,15 +104,15 @@ function UserFilter(props: UsersFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Admin/UserRoles/UserFilter/index.tsx
+++ b/src/views/Admin/UserRoles/UserFilter/index.tsx
@@ -63,9 +63,7 @@ const isActiveOptions = [
 
 interface UsersFilterProps {
     className?: string;
-    setUsersQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<UserListQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<UserListQueryVariables>) => void;
 }
 
 /*
@@ -84,7 +82,7 @@ const labelSelector = (item: ActiveOption) => item.label;
 function UserFilter(props: UsersFilterProps) {
     const {
         className,
-        setUsersQueryFilters,
+        handleFilterSet,
     } = props;
 
     const {
@@ -106,15 +104,15 @@ function UserFilter(props: UsersFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setUsersQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setUsersQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setUsersQueryFilters(finalValues);
-    }, [onValueSet, setUsersQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -118,7 +118,14 @@ function UserRoles(props: UserRolesProps) {
 
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const [usersQueryFilters, setUsersQueryFilters] = useState<PurgeNull<UserListQueryVariables>>();
+    const [usersQueryFilters,
+        setUsersQueryFilters,
+    ] = useState<PurgeNull<UserListQueryVariables>>();
+
+    const handleFilterSet = (value: PurgeNull<UserListQueryVariables>) => {
+        setUsersQueryFilters(value);
+        setPage(1);
+    };
 
     const usersVariables = useMemo(
         (): UserListQueryVariables => ({
@@ -294,7 +301,7 @@ function UserRoles(props: UserRolesProps) {
             )}
             description={(
                 <UserFilter
-                    setUsersQueryFilters={setUsersQueryFilters}
+                    handleFilterSet={handleFilterSet}
                 />
             )}
         >

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -118,14 +118,18 @@ function UserRoles(props: UserRolesProps) {
 
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(10);
-    const [usersQueryFilters,
+    const [
+        usersQueryFilters,
         setUsersQueryFilters,
     ] = useState<PurgeNull<UserListQueryVariables>>();
 
-    const handleFilterSet = (value: PurgeNull<UserListQueryVariables>) => {
-        setUsersQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<UserListQueryVariables>) => {
+            setUsersQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const usersVariables = useMemo(
         (): UserListQueryVariables => ({
@@ -301,7 +305,7 @@ function UserRoles(props: UserRolesProps) {
             )}
             description={(
                 <UserFilter
-                    handleFilterSet={handleFilterSet}
+                    onFilterChange={onFilterChange}
                 />
             )}
         >

--- a/src/views/Countries/CountriesFilter/index.tsx
+++ b/src/views/Countries/CountriesFilter/index.tsx
@@ -44,15 +44,13 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface CountriesFiltersProps {
     className?: string;
-    setCountriesQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<CountriesQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<CountriesQueryVariables>) => void;
 }
 
 function CountriesFilter(props: CountriesFiltersProps) {
     const {
         className,
-        setCountriesQueryFilters,
+        handleFilterSet,
     } = props;
 
     const [
@@ -77,15 +75,15 @@ function CountriesFilter(props: CountriesFiltersProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setCountriesQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setCountriesQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setCountriesQueryFilters(finalValues);
-    }, [onValueSet, setCountriesQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Countries/CountriesFilter/index.tsx
+++ b/src/views/Countries/CountriesFilter/index.tsx
@@ -44,13 +44,13 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface CountriesFiltersProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<CountriesQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<CountriesQueryVariables>) => void;
 }
 
 function CountriesFilter(props: CountriesFiltersProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
     } = props;
 
     const [
@@ -75,15 +75,15 @@ function CountriesFilter(props: CountriesFiltersProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Countries/index.tsx
+++ b/src/views/Countries/index.tsx
@@ -108,10 +108,13 @@ function Countries(props: CountriesProps) {
         setCountriesQueryFilters,
     ] = useState<PurgeNull<CountriesQueryVariables>>();
 
-    const handleFilterSet = (value: PurgeNull<CountriesQueryVariables>) => {
-        setCountriesQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<CountriesQueryVariables>) => {
+            setCountriesQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const countriesVariables = useMemo(
         (): CountriesQueryVariables => ({
@@ -246,7 +249,7 @@ function Countries(props: CountriesProps) {
                 )}
                 description={(
                     <CountriesFilter
-                        handleFilterSet={handleFilterSet}
+                        onFilterChange={onFilterChange}
                     />
                 )}
             >

--- a/src/views/Countries/index.tsx
+++ b/src/views/Countries/index.tsx
@@ -108,6 +108,11 @@ function Countries(props: CountriesProps) {
         setCountriesQueryFilters,
     ] = useState<PurgeNull<CountriesQueryVariables>>();
 
+    const handleFilterSet = (value: PurgeNull<CountriesQueryVariables>) => {
+        setCountriesQueryFilters(value);
+        setPage(1);
+    };
+
     const countriesVariables = useMemo(
         (): CountriesQueryVariables => ({
             ordering,
@@ -241,7 +246,7 @@ function Countries(props: CountriesProps) {
                 )}
                 description={(
                     <CountriesFilter
-                        setCountriesQueryFilters={setCountriesQueryFilters}
+                        handleFilterSet={handleFilterSet}
                     />
                 )}
             >

--- a/src/views/Crises/CrisesFilter/index.tsx
+++ b/src/views/Crises/CrisesFilter/index.tsx
@@ -61,13 +61,13 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface CrisesFilterProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<CrisesQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<CrisesQueryVariables>) => void;
 }
 
 function CrisesFilter(props: CrisesFilterProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
     } = props;
 
     const [
@@ -88,15 +88,15 @@ function CrisesFilter(props: CrisesFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const {
         data,

--- a/src/views/Crises/CrisesFilter/index.tsx
+++ b/src/views/Crises/CrisesFilter/index.tsx
@@ -61,15 +61,13 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface CrisesFilterProps {
     className?: string;
-    setCrisesQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<CrisesQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<CrisesQueryVariables>) => void;
 }
 
 function CrisesFilter(props: CrisesFilterProps) {
     const {
         className,
-        setCrisesQueryFilters,
+        handleFilterSet,
     } = props;
 
     const [
@@ -90,15 +88,15 @@ function CrisesFilter(props: CrisesFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setCrisesQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setCrisesQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setCrisesQueryFilters(finalValues);
-    }, [onValueSet, setCrisesQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const {
         data,

--- a/src/views/Crises/index.tsx
+++ b/src/views/Crises/index.tsx
@@ -147,10 +147,13 @@ function Crises(props: CrisesProps) {
         setCrisesQueryFilters,
     ] = useState<PurgeNull<CrisesQueryVariables>>();
 
-    const handleFilterSet = (value: PurgeNull<CrisesQueryVariables>) => {
-        setCrisesQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<CrisesQueryVariables>) => {
+            setCrisesQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const crisesVariables = useMemo(
         (): CrisesQueryVariables => ({
@@ -391,7 +394,7 @@ function Crises(props: CrisesProps) {
                 )}
                 description={(
                     <CrisesFilter
-                        handleFilterSet={handleFilterSet}
+                        onFilterChange={onFilterChange}
                     />
                 )}
                 footerContent={(

--- a/src/views/Crises/index.tsx
+++ b/src/views/Crises/index.tsx
@@ -147,6 +147,11 @@ function Crises(props: CrisesProps) {
         setCrisesQueryFilters,
     ] = useState<PurgeNull<CrisesQueryVariables>>();
 
+    const handleFilterSet = (value: PurgeNull<CrisesQueryVariables>) => {
+        setCrisesQueryFilters(value);
+        setPage(1);
+    };
+
     const crisesVariables = useMemo(
         (): CrisesQueryVariables => ({
             ordering,
@@ -386,7 +391,7 @@ function Crises(props: CrisesProps) {
                 )}
                 description={(
                     <CrisesFilter
-                        setCrisesQueryFilters={setCrisesQueryFilters}
+                        handleFilterSet={handleFilterSet}
                     />
                 )}
                 footerContent={(

--- a/src/views/Events/EventsFilter/index.tsx
+++ b/src/views/Events/EventsFilter/index.tsx
@@ -63,14 +63,14 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface EventsFilterProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<EventListQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<EventListQueryVariables>) => void;
     crisisSelectionDisabled: boolean;
 }
 
 function EventsFilter(props: EventsFilterProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
         crisisSelectionDisabled,
     } = props;
 
@@ -97,15 +97,15 @@ function EventsFilter(props: EventsFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const {
         data,

--- a/src/views/Events/EventsFilter/index.tsx
+++ b/src/views/Events/EventsFilter/index.tsx
@@ -63,16 +63,14 @@ const defaultFormValues: PartialForm<FormType> = {
 
 interface EventsFilterProps {
     className?: string;
-    setEventQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<EventListQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<EventListQueryVariables>) => void;
     crisisSelectionDisabled: boolean;
 }
 
 function EventsFilter(props: EventsFilterProps) {
     const {
         className,
-        setEventQueryFilters,
+        handleFilterSet,
         crisisSelectionDisabled,
     } = props;
 
@@ -99,15 +97,15 @@ function EventsFilter(props: EventsFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setEventQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setEventQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setEventQueryFilters(finalValues);
-    }, [onValueSet, setEventQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const {
         data,

--- a/src/views/Extraction/ExtractionEntriesTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/index.tsx
@@ -63,9 +63,9 @@ interface ExtractionEntriesTableProps {
     className?: string;
     extractionQueryFilters?: ExtractionEntryListFiltersQueryVariables;
     page: number;
-    setPage: React.Dispatch<React.SetStateAction<number>>;
+    onPageChange: React.Dispatch<React.SetStateAction<number>>;
     pageSize: number,
-    setPageSize: React.Dispatch<React.SetStateAction<number>>;
+    onPageSizeChange: React.Dispatch<React.SetStateAction<number>>;
 }
 
 function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
@@ -75,9 +75,9 @@ function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
         className,
         extractionQueryFilters,
         page,
-        setPage,
+        onPageChange,
         pageSize,
-        setPageSize,
+        onPageSizeChange,
     } = props;
 
     const sortState = useSortState();
@@ -275,8 +275,8 @@ function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
                     activePage={page}
                     itemsCount={totalEntriesCount}
                     maxItemsPerPage={pageSize}
-                    onActivePageChange={setPage}
-                    onItemsPerPageChange={setPageSize}
+                    onActivePageChange={onPageChange}
+                    onItemsPerPageChange={onPageSizeChange}
                 />
             )}
         >

--- a/src/views/Extraction/ExtractionEntriesTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useContext } from 'react';
+import React, { useMemo, useCallback, useContext } from 'react';
 import {
     useQuery,
     useMutation,
@@ -62,6 +62,10 @@ interface ExtractionEntriesTableProps {
     headingActions?: React.ReactNode;
     className?: string;
     extractionQueryFilters?: ExtractionEntryListFiltersQueryVariables;
+    page: number;
+    setPage: React.Dispatch<React.SetStateAction<number>>;
+    pageSize: number,
+    setPageSize: React.Dispatch<React.SetStateAction<number>>;
 }
 
 function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
@@ -70,7 +74,12 @@ function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
         headingActions,
         className,
         extractionQueryFilters,
+        page,
+        setPage,
+        pageSize,
+        setPageSize,
     } = props;
+
     const sortState = useSortState();
     const { sorting } = sortState;
     const validSorting = sorting ?? entriesDefaultSorting;
@@ -78,9 +87,6 @@ function ExtractionEntriesTable(props: ExtractionEntriesTableProps) {
     const ordering = validSorting.direction === 'asc'
         ? validSorting.name
         : `-${validSorting.name}`;
-
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(10);
 
     const variables = useMemo(() => ({
         ...extractionQueryFilters,

--- a/src/views/Extraction/NewExtractionFilters/index.tsx
+++ b/src/views/Extraction/NewExtractionFilters/index.tsx
@@ -109,12 +109,14 @@ interface NewExtractionFiltersProps {
     setExtractionQueryFiltersMeta: React.Dispatch<React.SetStateAction<
         { name?: string, id?: string }
     >>;
+    handleFilterSet: (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => void;
 }
 
 function NewExtractionFilters(props: NewExtractionFiltersProps) {
     const {
         id,
         className,
+        handleFilterSet,
         setExtractionQueryFilters,
         setExtractionQueryFiltersMeta,
     } = props;
@@ -248,14 +250,14 @@ function NewExtractionFilters(props: NewExtractionFiltersProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(initialFormValues);
-            setExtractionQueryFilters(initialFormValues);
+            handleFilterSet(initialFormValues);
             notify({
                 children: id
                     ? 'Filters reset successfully'
                     : 'Filters cleared successfully.',
             });
         },
-        [onValueSet, notify, id, initialFormValues, setExtractionQueryFilters],
+        [onValueSet, notify, id, initialFormValues, handleFilterSet],
     );
 
     const {
@@ -265,9 +267,9 @@ function NewExtractionFilters(props: NewExtractionFiltersProps) {
     } = useQuery<FormOptionsQuery>(FORM_OPTIONS);
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
-        setExtractionQueryFilters(finalValues);
+        handleFilterSet(finalValues);
         onPristineSet(true);
-    }, [setExtractionQueryFilters, onPristineSet]);
+    }, [handleFilterSet, onPristineSet]);
 
     const loading = extractionQueryLoading;
     const errored = !!extractionDataError;

--- a/src/views/Extraction/NewExtractionFilters/index.tsx
+++ b/src/views/Extraction/NewExtractionFilters/index.tsx
@@ -109,14 +109,14 @@ interface NewExtractionFiltersProps {
     setExtractionQueryFiltersMeta: React.Dispatch<React.SetStateAction<
         { name?: string, id?: string }
     >>;
-    handleFilterSet: (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => void;
 }
 
 function NewExtractionFilters(props: NewExtractionFiltersProps) {
     const {
         id,
         className,
-        handleFilterSet,
+        onFilterChange,
         setExtractionQueryFilters,
         setExtractionQueryFiltersMeta,
     } = props;
@@ -250,14 +250,14 @@ function NewExtractionFilters(props: NewExtractionFiltersProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(initialFormValues);
-            handleFilterSet(initialFormValues);
+            onFilterChange(initialFormValues);
             notify({
                 children: id
                     ? 'Filters reset successfully'
                     : 'Filters cleared successfully.',
             });
         },
-        [onValueSet, notify, id, initialFormValues, handleFilterSet],
+        [onValueSet, notify, id, initialFormValues, onFilterChange],
     );
 
     const {
@@ -267,9 +267,9 @@ function NewExtractionFilters(props: NewExtractionFiltersProps) {
     } = useQuery<FormOptionsQuery>(FORM_OPTIONS);
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
-        handleFilterSet(finalValues);
+        onFilterChange(finalValues);
         onPristineSet(true);
-    }, [handleFilterSet, onPristineSet]);
+    }, [onFilterChange, onPristineSet]);
 
     const loading = extractionQueryLoading;
     const errored = !!extractionDataError;

--- a/src/views/Extraction/index.tsx
+++ b/src/views/Extraction/index.tsx
@@ -14,6 +14,7 @@ import PageHeader from '#components/PageHeader';
 import QuickActionLink from '#components/QuickActionLink';
 import route from '#config/routes';
 import { reverseRoute } from '#hooks/useRouteMatching';
+import { PurgeNull } from '#types';
 
 import ExtractionEntriesTable from './ExtractionEntriesTable';
 import NewExtractionFilters from './NewExtractionFilters';
@@ -41,6 +42,11 @@ import styles from './styles.css';
 
 type NewExtractionFiltersFields = CreateExtractionMutationVariables['extraction'];
 
+interface ExtractionFiltersMetaProps {
+    name?: string,
+    id?: string
+}
+
 interface ExtractionProps {
     className?: string;
 }
@@ -59,6 +65,9 @@ function Extraction(props: ExtractionProps) {
         setPopupVisibility: React.Dispatch<React.SetStateAction<boolean>>;
     }>(null);
 
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+
     const [
         queryListFilters,
         setQueryListFilters,
@@ -76,7 +85,7 @@ function Extraction(props: ExtractionProps) {
     const [
         extractionQueryFiltersMeta,
         setExtractionQueryFiltersMeta,
-    ] = useState<{ name?: string, id?: string }>({});
+    ] = useState<ExtractionFiltersMetaProps>({});
 
     useLayoutEffect(
         () => {
@@ -85,6 +94,11 @@ function Extraction(props: ExtractionProps) {
         },
         [queryId],
     );
+
+    const handleFilterSet = (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => {
+        setExtractionQueryFilters(value);
+        setPage(1);
+    };
 
     let header = queryId ? 'Edit Query' : 'New Query';
     if (extractionQueryFiltersMeta?.name) {
@@ -322,11 +336,16 @@ function Extraction(props: ExtractionProps) {
                 <NewExtractionFilters
                     className={styles.container}
                     id={queryId}
+                    handleFilterSet={handleFilterSet}
                     setExtractionQueryFilters={setExtractionQueryFilters}
                     setExtractionQueryFiltersMeta={setExtractionQueryFiltersMeta}
                 />
                 <ExtractionEntriesTable
                     className={styles.largeContainer}
+                    page={page}
+                    setPage={setPage}
+                    pageSize={pageSize}
+                    setPageSize={setPageSize}
                     extractionQueryFilters={extractionQueryFilters}
                     headingActions={(
                         <>

--- a/src/views/Extraction/index.tsx
+++ b/src/views/Extraction/index.tsx
@@ -95,10 +95,13 @@ function Extraction(props: ExtractionProps) {
         [queryId],
     );
 
-    const handleFilterSet = (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => {
-        setExtractionQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => {
+            setExtractionQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     let header = queryId ? 'Edit Query' : 'New Query';
     if (extractionQueryFiltersMeta?.name) {
@@ -336,16 +339,16 @@ function Extraction(props: ExtractionProps) {
                 <NewExtractionFilters
                     className={styles.container}
                     id={queryId}
-                    handleFilterSet={handleFilterSet}
+                    onFilterChange={onFilterChange}
                     setExtractionQueryFilters={setExtractionQueryFilters}
                     setExtractionQueryFiltersMeta={setExtractionQueryFiltersMeta}
                 />
                 <ExtractionEntriesTable
                     className={styles.largeContainer}
                     page={page}
-                    setPage={setPage}
+                    onPageChange={setPage}
                     pageSize={pageSize}
-                    setPageSize={setPageSize}
+                    onPageSizeChange={setPageSize}
                     extractionQueryFilters={extractionQueryFilters}
                     headingActions={(
                         <>

--- a/src/views/Reports/ReportFilter/index.tsx
+++ b/src/views/Reports/ReportFilter/index.tsx
@@ -60,15 +60,13 @@ const STATUS_OPTIONS = gql`
 
 interface ReportFilterProps {
     className?: string;
-    setReportsQueryFilters: React.Dispatch<React.SetStateAction<
-        PurgeNull<ReportsQueryVariables> | undefined
-    >>;
+    handleFilterSet: (value: PurgeNull<ReportsQueryVariables>) => void;
 }
 
 function ReportFilter(props: ReportFilterProps) {
     const {
         className,
-        setReportsQueryFilters,
+        handleFilterSet,
     } = props;
 
     const [
@@ -95,15 +93,15 @@ function ReportFilter(props: ReportFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            setReportsQueryFilters(defaultFormValues);
+            handleFilterSet(defaultFormValues);
         },
-        [onValueSet, setReportsQueryFilters],
+        [onValueSet, handleFilterSet],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        setReportsQueryFilters(finalValues);
-    }, [onValueSet, setReportsQueryFilters]);
+        handleFilterSet(finalValues);
+    }, [onValueSet, handleFilterSet]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Reports/ReportFilter/index.tsx
+++ b/src/views/Reports/ReportFilter/index.tsx
@@ -60,13 +60,13 @@ const STATUS_OPTIONS = gql`
 
 interface ReportFilterProps {
     className?: string;
-    handleFilterSet: (value: PurgeNull<ReportsQueryVariables>) => void;
+    onFilterChange: (value: PurgeNull<ReportsQueryVariables>) => void;
 }
 
 function ReportFilter(props: ReportFilterProps) {
     const {
         className,
-        handleFilterSet,
+        onFilterChange,
     } = props;
 
     const [
@@ -93,15 +93,15 @@ function ReportFilter(props: ReportFilterProps) {
     const onResetFilters = useCallback(
         () => {
             onValueSet(defaultFormValues);
-            handleFilterSet(defaultFormValues);
+            onFilterChange(defaultFormValues);
         },
-        [onValueSet, handleFilterSet],
+        [onValueSet, onFilterChange],
     );
 
     const handleSubmit = React.useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
-        handleFilterSet(finalValues);
-    }, [onValueSet, handleFilterSet]);
+        onFilterChange(finalValues);
+    }, [onValueSet, onFilterChange]);
 
     const filterChanged = defaultFormValues !== value;
 

--- a/src/views/Reports/index.tsx
+++ b/src/views/Reports/index.tsx
@@ -133,6 +133,11 @@ function Reports(props: ReportsProps) {
         setReportsQueryFilters,
     ] = useState<PurgeNull<ReportsQueryVariables>>();
 
+    const handleFilterSet = (value: PurgeNull<ReportsQueryVariables>) => {
+        setReportsQueryFilters(value);
+        setPage(1);
+    };
+
     const reportsVariables = useMemo(
         (): ReportsQueryVariables => ({
             ordering,
@@ -327,7 +332,7 @@ function Reports(props: ReportsProps) {
                 )}
                 description={(
                     <ReportFilter
-                        setReportsQueryFilters={setReportsQueryFilters}
+                        handleFilterSet={handleFilterSet}
                     />
                 )}
             >

--- a/src/views/Reports/index.tsx
+++ b/src/views/Reports/index.tsx
@@ -133,10 +133,13 @@ function Reports(props: ReportsProps) {
         setReportsQueryFilters,
     ] = useState<PurgeNull<ReportsQueryVariables>>();
 
-    const handleFilterSet = (value: PurgeNull<ReportsQueryVariables>) => {
-        setReportsQueryFilters(value);
-        setPage(1);
-    };
+    const onFilterChange = React.useCallback(
+        (value: PurgeNull<ReportsQueryVariables>) => {
+            setReportsQueryFilters(value);
+            setPage(1);
+        },
+        [],
+    );
 
     const reportsVariables = useMemo(
         (): ReportsQueryVariables => ({
@@ -332,7 +335,7 @@ function Reports(props: ReportsProps) {
                 )}
                 description={(
                     <ReportFilter
-                        handleFilterSet={handleFilterSet}
+                        onFilterChange={onFilterChange}
                     />
                 )}
             >


### PR DESCRIPTION
## Changes
- Fix the issue related to the pagination of tables not being reset to 1, in all the tables that implements pagination feature

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
