### PR TITLE
Make actionColumn reusable

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
         "@togglecorp/fujs": "^1.9.2-beta.0",
         "@togglecorp/re-map": "^0.1.0",
         "@togglecorp/toggle-form": "^0.2.0-beta.6",
-        "@togglecorp/toggle-ui": "^0.11.0",
+        "@togglecorp/toggle-ui": "^0.11.1",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/combine": "^6.0.1",

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -107,19 +107,16 @@ function Navbar(props: Props) {
                             route={route.dashboard}
                         />
                         <SmartNavLink
-                            exact
                             className={styles.link}
                             activeClassName={styles.active}
                             route={route.countries}
                         />
                         <SmartNavLink
-                            exact
                             className={styles.link}
                             activeClassName={styles.active}
                             route={route.crises}
                         />
                         <SmartNavLink
-                            exact
                             className={styles.link}
                             activeClassName={styles.active}
                             route={route.events}
@@ -131,7 +128,6 @@ function Navbar(props: Props) {
                             route={route.extractions}
                         />
                         <SmartNavLink
-                            exact
                             className={styles.link}
                             activeClassName={styles.active}
                             route={route.reports}

--- a/src/components/tableHelpers/index.tsx
+++ b/src/components/tableHelpers/index.tsx
@@ -262,9 +262,9 @@ export function createActionColumn<D, K>(
         cellRendererParams: (_: K, datum: D): ActionProps => {
             const value = accessor(datum);
             return {
-                id: value?.id,
-                onEdit: value?.onEdit,
-                onDelete: value?.onDelete,
+                id: value.id,
+                onEdit: value.onEdit,
+                onDelete: value.onDelete,
             };
         },
     };

--- a/src/components/tableHelpers/index.tsx
+++ b/src/components/tableHelpers/index.tsx
@@ -13,6 +13,7 @@ import { RouteData, Attrs } from '#hooks/useRouteMatching';
 import Link, { LinkProps } from './Link';
 import ExternalLink, { ExternalLinkProps } from './ExternalLink';
 import Status, { StatusProps } from './Status';
+import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import Text, { TextProps } from './Text';
 import styles from './styles.css';
 
@@ -223,6 +224,47 @@ export function createStatusColumn<D, K>(
                 isReviewed: value?.isReviewed,
                 isSignedOff: value?.isSignedOff,
                 isUnderReview: value?.isUnderReview,
+            };
+        },
+    };
+    return item;
+}
+
+export function createActionColumn<D, K>(
+    id: string,
+    title: string,
+    accessor: (item: D) => {
+        id: string,
+        onEdit: ((id?: string | undefined) => void) | undefined,
+        onDelete: ((id: string) => void) | undefined,
+    },
+    options?: {
+        cellAsHeader?: boolean,
+        sortable?: boolean,
+        defaultSortDirection?: TableSortDirection,
+        filterType?: TableFilterType,
+        orderable?: boolean;
+        hideable?: boolean;
+    },
+) {
+    const item: TableColumn<D, K, ActionProps, TableHeaderCellProps> = {
+        id,
+        title,
+        cellAsHeader: options?.cellAsHeader,
+        headerCellRenderer: TableHeaderCell,
+        headerCellRendererParams: {
+            sortable: options?.sortable,
+            filterType: options?.filterType,
+            orderable: options?.orderable,
+            hideable: options?.hideable,
+        },
+        cellRenderer: ActionCell,
+        cellRendererParams: (_: K, datum: D): ActionProps => {
+            const value = accessor(datum);
+            return {
+                id: value?.id,
+                onEdit: value?.onEdit,
+                onDelete: value?.onDelete,
             };
         },
     };

--- a/src/components/tables/CommunicationAndPartners/CommunicationTable/index.tsx
+++ b/src/components/tables/CommunicationAndPartners/CommunicationTable/index.tsx
@@ -6,9 +6,6 @@ import {
 import {
     TextInput,
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     Pager,
     Button,
     useSortState,
@@ -17,12 +14,11 @@ import {
     SortContext,
 } from '@togglecorp/toggle-ui';
 import { _cs, isDefined } from '@togglecorp/fujs';
-import { createTextColumn } from '#components/tableHelpers';
+import { createTextColumn, createActionColumn } from '#components/tableHelpers';
 
 import Message from '#components/Message';
 import Container from '#components/Container';
 import Loading from '#components/Loading';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
 import { CountryOption } from '#components/selections/CountrySelectInput';
@@ -197,58 +193,48 @@ function CommunicationTable(props: CommunicationListProps) {
     const commPermissions = user?.permissions?.communication;
 
     const communicationColumns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<CommunicationFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
+        () => ([
+            createDateColumn<CommunicationFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createDateColumn<CommunicationFields, string>(
+                'date',
+                'Date of Communication',
+                (item) => item.date,
+                { sortable: true },
+            ),
+            createTextColumn<CommunicationFields, string>(
+                'subject',
+                'Subject',
+                (item) => item.subject,
+                { sortable: true, cellAsHeader: true },
+            ),
+            createTextColumn<CommunicationFields, string>(
+                'medium',
+                'Medium',
+                (item) => item.medium?.name,
+                { sortable: true },
+            ),
+            defaultCountry
+                ? undefined
+                : createTextColumn<CommunicationFields, string>(
+                    'country__name',
+                    'Country',
+                    (item) => item.country?.name,
+                ),
+            createActionColumn<CommunicationFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
                     onDelete: commPermissions?.delete ? handleCommunicationDelete : undefined,
                     onEdit: commPermissions?.change ? showAddCommunicationModal : undefined,
                 }),
-            };
-
-            return [
-                createDateColumn<CommunicationFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createDateColumn<CommunicationFields, string>(
-                    'date',
-                    'Date of Communication',
-                    (item) => item.date,
-                    { sortable: true },
-                ),
-                createTextColumn<CommunicationFields, string>(
-                    'subject',
-                    'Subject',
-                    (item) => item.subject,
-                    { sortable: true, cellAsHeader: true },
-                ),
-                createTextColumn<CommunicationFields, string>(
-                    'medium',
-                    'Medium',
-                    (item) => item.medium?.name,
-                    { sortable: true },
-                ),
-                defaultCountry
-                    ? undefined
-                    : createTextColumn<CommunicationFields, string>(
-                        'country__name',
-                        'Country',
-                        (item) => item.country?.name,
-                    ),
-                actionColumn,
-            ].filter(isDefined);
-        },
+            ),
+        ].filter(isDefined)),
         [
             defaultCountry,
             handleCommunicationDelete,

--- a/src/components/tables/EntriesTable/index.tsx
+++ b/src/components/tables/EntriesTable/index.tsx
@@ -185,7 +185,8 @@ function EntriesTable(props: EntriesTableProps) {
         (value: PurgeNull<EntriesQueryVariables>) => {
             setEntriesQueryFilters(value);
             setPage(1);
-        }, [],
+        },
+        [],
     );
 
     const entriesVariables = useMemo(

--- a/src/components/tables/EntriesTable/index.tsx
+++ b/src/components/tables/EntriesTable/index.tsx
@@ -185,8 +185,7 @@ function EntriesTable(props: EntriesTableProps) {
         (value: PurgeNull<EntriesQueryVariables>) => {
             setEntriesQueryFilters(value);
             setPage(1);
-        },
-        [],
+        }, [],
     );
 
     const entriesVariables = useMemo(

--- a/src/views/Actors/ActorTable/index.tsx
+++ b/src/views/Actors/ActorTable/index.tsx
@@ -3,9 +3,6 @@ import { gql, useQuery, useMutation } from '@apollo/client';
 import { _cs } from '@togglecorp/fujs';
 import {
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     useSortState,
     SortContext,
     Pager,
@@ -13,14 +10,13 @@ import {
     Button,
     createDateColumn,
 } from '@togglecorp/toggle-ui';
-import { createTextColumn } from '#components/tableHelpers';
 import { PurgeNull } from '#types';
+import { createTextColumn, createActionColumn } from '#components/tableHelpers';
 
 import Message from '#components/Message';
 import Container from '#components/Container';
 import NotificationContext from '#components/NotificationContext';
 import Loading from '#components/Loading';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 
 import useModalState from '#hooks/useModalState';
@@ -184,51 +180,41 @@ function ActorTable(props: ActorProps) {
     const totalActorsCount = actors?.actorList?.totalCount ?? 0;
 
     const actorColumns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<ActorFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
+        () => ([
+            createDateColumn<ActorFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createTextColumn<ActorFields, string>(
+                'name',
+                'Name',
+                (item) => item.name,
+                { cellAsHeader: true, sortable: true },
+            ),
+            createTextColumn<ActorFields, string>(
+                'country__idmc_short_name',
+                'Country',
+                (item) => item.country?.idmcShortName,
+                { sortable: true },
+            ),
+            createTextColumn<ActorFields, string>(
+                'torg',
+                'Torg',
+                (item) => item.torg,
+                { sortable: true },
+            ),
+            createActionColumn<ActorFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
                     onEdit: actorPermissions?.change ? showAddActorModal : undefined,
                     onDelete: actorPermissions?.delete ? handleActorDelete : undefined,
                 }),
-            };
-
-            return [
-                createDateColumn<ActorFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createTextColumn<ActorFields, string>(
-                    'name',
-                    'Name',
-                    (item) => item.name,
-                    { cellAsHeader: true, sortable: true },
-                ),
-                createTextColumn<ActorFields, string>(
-                    'country__idmc_short_name',
-                    'Country',
-                    (item) => item.country?.idmcShortName,
-                    { sortable: true },
-                ),
-                createTextColumn<ActorFields, string>(
-                    'torg',
-                    'Torg',
-                    (item) => item.torg,
-                    { sortable: true },
-                ),
-                actionColumn,
-            ];
-        },
+            ),
+        ]),
         [
             showAddActorModal,
             handleActorDelete,

--- a/src/views/ContextualUpdates/index.tsx
+++ b/src/views/ContextualUpdates/index.tsx
@@ -7,9 +7,6 @@ import {
 import { _cs } from '@togglecorp/fujs';
 import {
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     useSortState,
     Pager,
     createDateColumn,
@@ -18,6 +15,7 @@ import {
 import {
     createTextColumn,
     createLinkColumn,
+    createActionColumn,
 } from '#components/tableHelpers';
 import { PurgeNull } from '#types';
 
@@ -25,7 +23,6 @@ import Message from '#components/Message';
 import Loading from '#components/Loading';
 import Container from '#components/Container';
 import PageHeader from '#components/PageHeader';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
 
@@ -190,65 +187,56 @@ function ContextualUpdates(props: ContextualUpdatesProps) {
     const contextualUpdatePermissions = user?.permissions?.contextualupdate;
 
     const columns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<ContextualUpdateFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
+        () => ([
+            createDateColumn<ContextualUpdateFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createLinkColumn<ContextualUpdateFields, string>(
+                'articleTitle',
+                'Name',
+                (item) => ({
+                    title: item.articleTitle,
+                    attrs: { contextualUpdateId: item.id },
+                }),
+                route.contextualUpdateView,
+                { cellAsHeader: true, sortable: true },
+            ),
+            createTextColumn<ContextualUpdateFields, string>(
+                'countries',
+                'Countries',
+                (item) => item.countries.map((c) => c.idmcShortName).join(', '),
+            ),
+            createDateColumn<ContextualUpdateFields, string>(
+                'publish_date',
+                'Publish Date',
+                (item) => item.publishDate,
+                { sortable: true },
+            ),
+            createTextColumn<ContextualUpdateFields, string>(
+                'publishers',
+                'Publishers',
+                (item) => item.publishers?.results?.map((p) => p.name).join(', '),
+            ),
+            createTextColumn<ContextualUpdateFields, string>(
+                'sources',
+                'Sources',
+                (item) => item.sources?.results?.map((s) => s.name).join(', '),
+            ),
+            createActionColumn<ContextualUpdateFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
+                    onEdit: undefined,
                     onDelete: contextualUpdatePermissions?.delete
                         ? handleContextualUpdateDelete
                         : undefined,
                 }),
-            };
-
-            return [
-                createDateColumn<ContextualUpdateFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createLinkColumn<ContextualUpdateFields, string>(
-                    'articleTitle',
-                    'Name',
-                    (item) => ({
-                        title: item.articleTitle,
-                        attrs: { contextualUpdateId: item.id },
-                    }),
-                    route.contextualUpdateView,
-                    { cellAsHeader: true, sortable: true },
-                ),
-                createTextColumn<ContextualUpdateFields, string>(
-                    'countries',
-                    'Countries',
-                    (item) => item.countries.map((c) => c.idmcShortName).join(', '),
-                ),
-                createDateColumn<ContextualUpdateFields, string>(
-                    'publish_date',
-                    'Publish Date',
-                    (item) => item.publishDate,
-                    { sortable: true },
-                ),
-                createTextColumn<ContextualUpdateFields, string>(
-                    'publishers',
-                    'Publishers',
-                    (item) => item.publishers?.results?.map((p) => p.name).join(', '),
-                ),
-                createTextColumn<ContextualUpdateFields, string>(
-                    'sources',
-                    'Sources',
-                    (item) => item.sources?.results?.map((s) => s.name).join(', '),
-                ),
-                actionColumn,
-            ];
-        },
+            ),
+        ]),
         [
             handleContextualUpdateDelete,
             contextualUpdatePermissions?.delete,

--- a/src/views/Crises/index.tsx
+++ b/src/views/Crises/index.tsx
@@ -21,6 +21,7 @@ import {
     createTextColumn,
     createNumberColumn,
     createLinkColumn,
+    createActionColumn,
 } from '#components/tableHelpers';
 import { PurgeNull } from '#types';
 
@@ -29,7 +30,6 @@ import Loading from '#components/Loading';
 import Container from '#components/Container';
 import PageHeader from '#components/PageHeader';
 import CrisisForm from '#components/forms/CrisisForm';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import StackedProgressCell, { StackedProgressProps } from '#components/tableHelpers/StackedProgress';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
@@ -254,22 +254,6 @@ function Crises(props: CrisesProps) {
     const columns = useMemo(
         () => {
             // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<CrisisFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
-                    onDelete: crisisPermissions?.delete ? handleCrisisDelete : undefined,
-                    onEdit: crisisPermissions?.change ? showAddCrisisModal : undefined,
-                }),
-            };
-
-            // eslint-disable-next-line max-len
             const progressColumn: TableColumn<CrisisFields, string, StackedProgressProps, TableHeaderCellProps> = {
                 id: 'progress',
                 title: 'Progress',
@@ -349,8 +333,16 @@ function Crises(props: CrisesProps) {
                     (item) => item.totalStockIdpFigures,
                     { sortable: true },
                 ),
+                createActionColumn<CrisisFields, string>(
+                    'action',
+                    '',
+                    (item) => ({
+                        id: item.id,
+                        onDelete: crisisPermissions?.delete ? handleCrisisDelete : undefined,
+                        onEdit: crisisPermissions?.change ? showAddCrisisModal : undefined,
+                    }),
+                ),
                 progressColumn,
-                actionColumn,
             ];
         },
         [

--- a/src/views/Entry/EntryForm/DetailsInput/index.tsx
+++ b/src/views/Entry/EntryForm/DetailsInput/index.tsx
@@ -248,6 +248,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
                         name="documentUrl"
                         error={error?.fields?.documentUrl}
                         disabled={disabledFromProps}
+                        readOnly={!editMode}
                     />
                 </Row>
             )}

--- a/src/views/FigureTags/FigureTagsTable/index.tsx
+++ b/src/views/FigureTags/FigureTagsTable/index.tsx
@@ -7,9 +7,6 @@ import {
 import { isDefined } from '@togglecorp/fujs';
 import {
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     useSortState,
     Pager,
     Modal,
@@ -17,13 +14,12 @@ import {
     SortContext,
     createDateColumn,
 } from '@togglecorp/toggle-ui';
-import { createTextColumn } from '#components/tableHelpers';
 import { PurgeNull } from '#types';
+import { createTextColumn, createActionColumn } from '#components/tableHelpers';
 
 import Message from '#components/Message';
 import Loading from '#components/Loading';
 import Container from '#components/Container';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
@@ -185,45 +181,35 @@ function FigureTagsTable(props: FigureTagsProps) {
     const figureTagPermissions = user?.permissions?.figure;
 
     const columns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<FigureTagFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
+        () => ([
+            createDateColumn<FigureTagFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createTextColumn<FigureTagFields, string>(
+                'created_by__full_name',
+                'Created by',
+                (item) => item.createdBy?.fullName,
+                { sortable: true },
+            ),
+            createTextColumn<FigureTagFields, string>(
+                'name',
+                'Name',
+                (item) => item.name,
+                { cellAsHeader: true, sortable: true },
+            ),
+            createActionColumn<FigureTagFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
                     onDelete: figureTagPermissions?.delete ? handleFigureTagDelete : undefined,
                     onEdit: figureTagPermissions?.change ? showAddFigureTagModal : undefined,
                 }),
-            };
-
-            return [
-                createDateColumn<FigureTagFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createTextColumn<FigureTagFields, string>(
-                    'created_by__full_name',
-                    'Created by',
-                    (item) => item.createdBy?.fullName,
-                    { sortable: true },
-                ),
-                createTextColumn<FigureTagFields, string>(
-                    'name',
-                    'Name',
-                    (item) => item.name,
-                    { cellAsHeader: true, sortable: true },
-                ),
-                actionColumn,
-            ].filter(isDefined);
-        },
+            ),
+        ].filter(isDefined)),
         [
             showAddFigureTagModal,
             handleFigureTagDelete,

--- a/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
+++ b/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
@@ -157,7 +157,7 @@ const schema: FormSchema = {
     fields: (): FormSchemaFields => ({
         id: [idCondition],
         organizationKind: [],
-        shortName: [requiredStringCondition, lengthSmallerThanCondition(6)],
+        shortName: [lengthSmallerThanCondition(6)],
         name: [requiredStringCondition],
         methodology: [requiredStringCondition],
         breakdown: [],

--- a/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
+++ b/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
@@ -15,7 +15,6 @@ import {
     removeNull,
     idCondition,
     requiredStringCondition,
-    lengthSmallerThanCondition,
     requiredCondition,
 } from '@togglecorp/toggle-form';
 import {
@@ -157,7 +156,7 @@ const schema: FormSchema = {
     fields: (): FormSchemaFields => ({
         id: [idCondition],
         organizationKind: [],
-        shortName: [lengthSmallerThanCondition(6)],
+        shortName: [],
         name: [requiredStringCondition],
         methodology: [requiredStringCondition],
         breakdown: [],
@@ -352,7 +351,7 @@ function OrganizationForm(props: OrganizationFormProps) {
                     disabled={disabled}
                 />
                 <TextInput
-                    label="Short Name *"
+                    label="Short Name"
                     value={value.shortName}
                     onChange={onValueChange}
                     name="shortName"

--- a/src/views/Organizations/OrganizationTable/index.tsx
+++ b/src/views/Organizations/OrganizationTable/index.tsx
@@ -3,9 +3,6 @@ import { gql, useQuery, useMutation } from '@apollo/client';
 import { _cs } from '@togglecorp/fujs';
 import {
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     useSortState,
     Pager,
     Modal,
@@ -14,13 +11,12 @@ import {
     createDateColumn,
 } from '@togglecorp/toggle-ui';
 import { PurgeNull } from '#types';
-import { createTextColumn } from '#components/tableHelpers';
+import { createTextColumn, createActionColumn } from '#components/tableHelpers';
 
 import Message from '#components/Message';
 import Container from '#components/Container';
 import NotificationContext from '#components/NotificationContext';
 import Loading from '#components/Loading';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 
 import useModalState from '#hooks/useModalState';
@@ -187,62 +183,52 @@ function OrganizationTable(props: OrganizationProps) {
     const loading = organizationsLoading || deleteOrganizationLoading;
 
     const organizationColumns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<OrganizationFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
+        () => ([
+            createDateColumn<OrganizationFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createTextColumn<OrganizationFields, string>(
+                'name',
+                'Name',
+                (item) => item.name,
+                { cellAsHeader: true, sortable: true },
+            ),
+            createTextColumn<OrganizationFields, string>(
+                'short_name',
+                'Short Name',
+                (item) => item.shortName,
+                { sortable: true },
+            ),
+            createTextColumn<OrganizationFields, string>(
+                'category',
+                'Category',
+                (item) => item.category,
+                { sortable: true },
+            ),
+            createTextColumn<OrganizationFields, string>(
+                'countries',
+                'Countries',
+                (item) => item.countries.map((c) => c.idmcShortName).join(', '),
+            ),
+            createTextColumn<OrganizationFields, string>(
+                'organization_kind__name',
+                'Organization Type',
+                (item) => item.organizationKind?.name,
+                { sortable: true },
+            ),
+            createActionColumn<OrganizationFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
                     onEdit: orgPermissions?.change ? showAddOrganizationModal : undefined,
                     onDelete: orgPermissions?.delete ? handleOrganizationDelete : undefined,
                 }),
-            };
-
-            return [
-                createDateColumn<OrganizationFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createTextColumn<OrganizationFields, string>(
-                    'name',
-                    'Name',
-                    (item) => item.name,
-                    { cellAsHeader: true, sortable: true },
-                ),
-                createTextColumn<OrganizationFields, string>(
-                    'short_name',
-                    'Short Name',
-                    (item) => item.shortName,
-                    { sortable: true },
-                ),
-                createTextColumn<OrganizationFields, string>(
-                    'category',
-                    'Category',
-                    (item) => item.category,
-                    { sortable: true },
-                ),
-                createTextColumn<OrganizationFields, string>(
-                    'countries',
-                    'Countries',
-                    (item) => item.countries.map((c) => c.idmcShortName).join(', '),
-                ),
-                createTextColumn<OrganizationFields, string>(
-                    'organization_kind__name',
-                    'Organization Type',
-                    (item) => item.organizationKind?.name,
-                    { sortable: true },
-                ),
-                actionColumn,
-            ];
-        },
+            ),
+        ]),
         [
             showAddOrganizationModal,
             handleOrganizationDelete,

--- a/src/views/Reports/index.tsx
+++ b/src/views/Reports/index.tsx
@@ -7,9 +7,6 @@ import {
 import { _cs } from '@togglecorp/fujs';
 import {
     Table,
-    TableColumn,
-    TableHeaderCell,
-    TableHeaderCellProps,
     useSortState,
     Pager,
     Modal,
@@ -27,7 +24,6 @@ import {
 import { PurgeNull } from '#types';
 
 import useModalState from '#hooks/useModalState';
-import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
 import Message from '#components/Message';
@@ -205,103 +201,84 @@ function Reports(props: ReportsProps) {
     const reportPermissions = user?.permissions?.report;
 
     const columns = useMemo(
-        () => {
-            // eslint-disable-next-line max-len
-            const actionColumn: TableColumn<ReportFields, string, ActionProps, TableHeaderCellProps> = {
-                id: 'action',
-                title: '',
-                headerCellRenderer: TableHeaderCell,
-                headerCellRendererParams: {
-                    sortable: false,
-                },
-                cellRenderer: ActionCell,
-                cellRendererParams: (_, datum) => ({
-                    id: datum.id,
-                    onDelete: reportPermissions?.delete ? handleReportDelete : undefined,
-                    onEdit: reportPermissions?.change ? showAddReportModal : undefined,
+        () => ([
+            createDateColumn<ReportFields, string>(
+                'created_at',
+                'Date Created',
+                (item) => item.createdAt,
+                { sortable: true },
+            ),
+            createTextColumn<ReportFields, string>(
+                'created_by__full_name',
+                'Created by',
+                (item) => item.createdBy?.fullName,
+                { sortable: true },
+            ),
+            createLinkColumn<ReportFields, string>(
+                'name',
+                'Name',
+                (item) => ({
+                    title: item.name,
+                    attrs: { reportId: item.id },
                 }),
-            };
-
-            return [
-                createDateColumn<ReportFields, string>(
-                    'created_at',
-                    'Date Created',
-                    (item) => item.createdAt,
-                    { sortable: true },
-                ),
-                createTextColumn<ReportFields, string>(
-                    'created_by__full_name',
-                    'Created by',
-                    (item) => item.createdBy?.fullName,
-                    { sortable: true },
-                ),
-                createLinkColumn<ReportFields, string>(
-                    'name',
-                    'Name',
-                    (item) => ({
-                        title: item.name,
-                        attrs: { reportId: item.id },
-                    }),
-                    route.report,
-                    { cellAsHeader: true, sortable: true },
-                ),
-                createDateColumn<ReportFields, string>(
-                    'figure_start_after',
-                    'Start Date of Report',
-                    (item) => item.filterFigureStartAfter,
-                    { sortable: true },
-                ),
-                createDateColumn<ReportFields, string>(
-                    'figure_end_before',
-                    'End Date of Report',
-                    (item) => item.filterFigureEndBefore,
-                    { sortable: true },
-                ),
-                createNumberColumn<ReportFields, string>(
-                    'total_flow_conflict',
-                    'New Displacements (Conflict)',
-                    (item) => item.totalDisaggregation.totalFlowConflictSum,
-                    // { sortable: true },
-                ),
-                createNumberColumn<ReportFields, string>(
-                    'total_stock_conflict',
-                    'No. of IDPs (Conflict)',
-                    (item) => item.totalDisaggregation.totalStockConflictSum,
-                    // { sortable: true },
-                ),
-                createNumberColumn<ReportFields, string>(
-                    'total_flow_disaster',
-                    'New Displacements (Disaster)',
-                    (item) => item.totalDisaggregation.totalFlowDisasterSum,
-                    // { sortable: true },
-                ),
-                createNumberColumn<ReportFields, string>(
-                    'total_stock_disaster',
-                    'No. of IDPs (Disaster)',
-                    (item) => item.totalDisaggregation.totalStockDisasterSum,
-                    // { sortable: true },
-                ),
-                createStatusColumn<ReportFields, string>(
-                    'status',
-                    '',
-                    (item) => ({
-                        isUnderReview: false,
-                        isReviewed: item?.lastGeneration?.isApproved,
-                        isSignedOff: item?.lastGeneration?.isSignedOff,
-                    }),
-                ),
-                createActionColumn<ReportFields, string>(
-                    'action',
-                    '',
-                    (item) => ({
-                        id: item?.id,
-                        onEdit: reportPermissions?.change ? showAddReportModal : undefined,
-                        onDelete: reportPermissions?.delete ? handleReportDelete : undefined,
-                    }),
-                ),
-                // actionColumn,
-            ];
-        },
+                route.report,
+                { cellAsHeader: true, sortable: true },
+            ),
+            createDateColumn<ReportFields, string>(
+                'figure_start_after',
+                'Start Date of Report',
+                (item) => item.filterFigureStartAfter,
+                { sortable: true },
+            ),
+            createDateColumn<ReportFields, string>(
+                'figure_end_before',
+                'End Date of Report',
+                (item) => item.filterFigureEndBefore,
+                { sortable: true },
+            ),
+            createNumberColumn<ReportFields, string>(
+                'total_flow_conflict',
+                'New Displacements (Conflict)',
+                (item) => item.totalDisaggregation.totalFlowConflictSum,
+                // { sortable: true },
+            ),
+            createNumberColumn<ReportFields, string>(
+                'total_stock_conflict',
+                'No. of IDPs (Conflict)',
+                (item) => item.totalDisaggregation.totalStockConflictSum,
+                // { sortable: true },
+            ),
+            createNumberColumn<ReportFields, string>(
+                'total_flow_disaster',
+                'New Displacements (Disaster)',
+                (item) => item.totalDisaggregation.totalFlowDisasterSum,
+                // { sortable: true },
+            ),
+            createNumberColumn<ReportFields, string>(
+                'total_stock_disaster',
+                'No. of IDPs (Disaster)',
+                (item) => item.totalDisaggregation.totalStockDisasterSum,
+                // { sortable: true },
+            ),
+            createStatusColumn<ReportFields, string>(
+                'status',
+                '',
+                (item) => ({
+                    isUnderReview: false,
+                    isReviewed: item.lastGeneration?.isApproved,
+                    isSignedOff: item.lastGeneration?.isSignedOff,
+                }),
+            ),
+            createActionColumn<ReportFields, string>(
+                'action',
+                '',
+                (item) => ({
+                    id: item.id,
+                    onEdit: reportPermissions?.change ? showAddReportModal : undefined,
+                    onDelete: reportPermissions?.delete ? handleReportDelete : undefined,
+                }),
+            ),
+        ]),
         [
             showAddReportModal,
             handleReportDelete,

--- a/src/views/Reports/index.tsx
+++ b/src/views/Reports/index.tsx
@@ -22,6 +22,7 @@ import {
     createLinkColumn,
     createStatusColumn,
     createNumberColumn,
+    createActionColumn,
 } from '#components/tableHelpers';
 import { PurgeNull } from '#types';
 
@@ -289,7 +290,16 @@ function Reports(props: ReportsProps) {
                         isSignedOff: item?.lastGeneration?.isSignedOff,
                     }),
                 ),
-                actionColumn,
+                createActionColumn<ReportFields, string>(
+                    'action',
+                    '',
+                    (item) => ({
+                        id: item?.id,
+                        onEdit: reportPermissions?.change ? showAddReportModal : undefined,
+                        onDelete: reportPermissions?.delete ? handleReportDelete : undefined,
+                    }),
+                ),
+                // actionColumn,
             ];
         },
         [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,10 +3765,10 @@
     "@storybook/client-api" "^6.0.21"
     "@togglecorp/fujs" "^1.9.2-beta.0"
 
-"@togglecorp/toggle-ui@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.11.0.tgz#ada136d848af2c9f4376cdbc7407e18e78254fa6"
-  integrity sha512-gsPFWrcw9CQ1NxGCgquDUQXuD799d+b/BX+sjfHtpz9CoaUUveJUAQ+GiPM/bz7Prd10Je94sYOlKEM6r7PV3A==
+"@togglecorp/toggle-ui@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.11.1.tgz#3b344e57dc74878dcbad400f8f962a910839f761"
+  integrity sha512-4qeaUQXOGUz3/Fr5eFv5/aN104EA2s7s5IcRb9Fbmwg9aY8t4SAMctIJC4F1tq+b+Y9/C+r4w8/+IHyZ4qdgpQ==
   dependencies:
     "@babel/runtime-corejs3" "^7.11.2"
     "@togglecorp/fujs" "^1.9.2-beta.0"
@@ -3776,7 +3776,7 @@
     d3-axis "^2.0.0"
     d3-scale "^3.2.3"
     file-saver "^2.0.2"
-    react-icons "^3.11.0"
+    react-icons "^4.2.0"
     react-textarea-autosize "^8.3.3"
     resize-observer-polyfill "^1.5.1"
 
@@ -14291,13 +14291,6 @@ react-dom@^0.0.0-experimental-3d0895557:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "0.0.0-experimental-3d0895557"
-
-react-icons@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.11.0.tgz#2ca2903dfab8268ca18ebd8cc2e879921ec3b254"
-  integrity sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==
-  dependencies:
-    camelcase "^5.0.0"
 
 react-icons@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Addresses:
- ShortName field should not be mandatory : https://github.com/idmc-labs/Helix2.0/issues/168#issue-937194080

## Changes
- Make "actionColumn" as a reusable element in table-helpers 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
