### PR TITLE
Add showMap button for maps in Extraction Entry

### DIFF
--- a/src/components/MarkdownEditor/index.tsx
+++ b/src/components/MarkdownEditor/index.tsx
@@ -1,7 +1,32 @@
 import React, { useCallback } from 'react';
 import { InputContainer, InputContainerProps } from '@togglecorp/toggle-ui';
 import Markdown from 'react-mde';
-import MarkdownView from 'react-showdown';
+import MarkdownView, { MarkdownViewProps } from 'react-showdown';
+
+export const markdownOptions: MarkdownViewProps['options'] = {
+    simpleLineBreaks: true,
+    headerLevelStart: 3,
+    simplifiedAutoLink: true,
+    openLinksInNewWindow: true,
+    backslashEscapesHTMLTags: true,
+    literalMidWordUnderscores: true,
+    strikethrough: true,
+    tables: true,
+    tasklists: true,
+};
+
+export function MarkdownPreview(props: MarkdownViewProps) {
+    const {
+        options: markdownOptionsFromProps,
+        ...otherProps
+    } = props;
+    return (
+        <MarkdownView
+            {...otherProps}
+            options={markdownOptionsFromProps ?? markdownOptions}
+        />
+    );
+}
 
 interface MarkdownEditorProps<K extends string> {
     name: K;
@@ -13,18 +38,6 @@ interface MarkdownEditorProps<K extends string> {
 }
 
 export type Props<K extends string> = Omit<InputContainerProps, 'input'> & MarkdownEditorProps<K>;
-
-export const markdownOptions = {
-    simpleLineBreaks: true,
-    headerLevelStart: 3,
-    simplifiedAutoLink: true,
-    openLinksInNewWindow: true,
-    backslashEscapesHTMLTags: true,
-    literalMidWordUnderscores: true,
-    strikethrough: true,
-    tables: true,
-    tasklists: true,
-};
 
 function MarkdownEditor<K extends string>(props: Props<K>) {
     const {
@@ -59,9 +72,8 @@ function MarkdownEditor<K extends string>(props: Props<K>) {
 
     const generateMarkdownPreview = useCallback((markdown: string | undefined) => (
         Promise.resolve(
-            <MarkdownView
+            <MarkdownPreview
                 markdown={markdown ?? ''}
-                options={markdownOptions}
             />,
         )
     ), []);
@@ -93,9 +105,8 @@ function MarkdownEditor<K extends string>(props: Props<K>) {
                     readOnly={disabled}
                 />
             ) : (
-                <MarkdownView
-                    markdown={value ?? ''}
-                    options={markdownOptions}
+                <MarkdownPreview
+                    markdown={value || '-'}
                 />
             )}
         />

--- a/src/views/Country/ContextualAnalysis/ContextualHistoryList/index.tsx
+++ b/src/views/Country/ContextualAnalysis/ContextualHistoryList/index.tsx
@@ -5,7 +5,7 @@ import { Pager, DateTime } from '@togglecorp/toggle-ui';
 import { _cs } from '@togglecorp/fujs';
 
 import Container from '#components/Container';
-import MarkdownEditor from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import Row from '#components/Row';
 
 import {
@@ -105,10 +105,8 @@ function ContextualHistoryList(props: ContextualHistoryProps) {
                     )}
                     {context.update && (
                         <Row>
-                            <MarkdownEditor
-                                name="update"
-                                readOnly
-                                value={context.update}
+                            <MarkdownPreview
+                                markdown={context.update}
                             />
                         </Row>
                     )}

--- a/src/views/Country/ContextualAnalysis/index.tsx
+++ b/src/views/Country/ContextualAnalysis/index.tsx
@@ -6,7 +6,7 @@ import { Modal, DateTime } from '@togglecorp/toggle-ui';
 
 import Message from '#components/Message';
 import Container from '#components/Container';
-import MarkdownEditor from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import DomainContext from '#components/DomainContext';
 
 import QuickActionButton from '#components/QuickActionButton';
@@ -121,10 +121,8 @@ function ContextualAnalysis(props: CountryContextualAnalysisProps) {
                     )}
                     {contextualAnalysis.update && (
                         <Row className={_cs(styles.row, styles.update)}>
-                            <MarkdownEditor
-                                value={contextualAnalysis.update}
-                                name="update"
-                                readOnly
+                            <MarkdownPreview
+                                markdown={contextualAnalysis.update}
                             />
                         </Row>
                     )}

--- a/src/views/Country/CountrySummary/SummaryHistoryList/index.tsx
+++ b/src/views/Country/CountrySummary/SummaryHistoryList/index.tsx
@@ -5,7 +5,7 @@ import { Pager, DateTime } from '@togglecorp/toggle-ui';
 import { _cs } from '@togglecorp/fujs';
 
 import Container from '#components/Container';
-import MarkdownEditor from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 
 import {
     SummaryHistoryQuery,
@@ -86,10 +86,8 @@ function SummaryHistoryList(props: SummaryHistoryProps) {
                         value={summary.createdAt}
                         format="datetime"
                     />
-                    <MarkdownEditor
-                        name="update"
-                        readOnly
-                        value={summary.summary}
+                    <MarkdownPreview
+                        markdown={summary.summary}
                     />
                 </div>
             ))}

--- a/src/views/Country/CountrySummary/index.tsx
+++ b/src/views/Country/CountrySummary/index.tsx
@@ -11,7 +11,7 @@ import { CountryQuery, CreateSummaryMutation } from '#generated/types';
 import Message from '#components/Message';
 import Container from '#components/Container';
 import QuickActionButton from '#components/QuickActionButton';
-import MarkdownEditor from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import DomainContext from '#components/DomainContext';
 
 import CountrySummaryForm from './CountrySummaryForm';
@@ -95,10 +95,8 @@ function CountrySummary(props: CountrySummaryProps) {
             )}
             {summary ? (
                 <div className={styles.summaryText}>
-                    <MarkdownEditor
-                        value={summary.summary}
-                        name="update"
-                        readOnly
+                    <MarkdownPreview
+                        markdown={summary.summary}
                     />
                 </div>
             ) : (

--- a/src/views/Country/index.tsx
+++ b/src/views/Country/index.tsx
@@ -295,7 +295,7 @@ function Country(props: CountryProps) {
                                             {`(Disaster ${year})`}
                                         </>
                                     )}
-                                    value={countryData?.country?.totalFlowDisaster}
+                                    value={countryData?.country?.totalStockDisaster}
                                 />
                                 <NumberBlock
                                     label={(

--- a/src/views/Crisis/index.tsx
+++ b/src/views/Crisis/index.tsx
@@ -9,9 +9,8 @@ import {
     Button,
     Modal,
 } from '@togglecorp/toggle-ui';
-import MarkdownView from 'react-showdown';
 
-import { markdownOptions } from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import DomainContext from '#components/DomainContext';
 import Container from '#components/Container';
 import PageHeader from '#components/PageHeader';
@@ -135,9 +134,8 @@ function Crisis(props: CrisisProps) {
                 className={styles.container}
                 heading="Narrative"
             >
-                <MarkdownView
+                <MarkdownPreview
                     markdown={crisisData?.crisis?.crisisNarrative ?? 'Narrative not available'}
-                    options={markdownOptions}
                 />
             </Container>
             <EventsTable

--- a/src/views/Entry/EntryForm/DetailsInput/index.tsx
+++ b/src/views/Entry/EntryForm/DetailsInput/index.tsx
@@ -375,7 +375,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
             <Row>
                 <MarkdownEditor
                     label="Source Methodology"
-                    value={methodology ?? '-'}
+                    value={methodology}
                     name="sourceMethodology"
                     disabled={disabled}
                     readOnly
@@ -384,7 +384,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
             <Row>
                 <MarkdownEditor
                     label="Source Breakdown and Reliability"
-                    value={breakdown ?? '-'}
+                    value={breakdown}
                     name="sourceBreakdown"
                     disabled={disabled}
                     readOnly

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -164,6 +164,7 @@ function FigureInput(props: FigureInputProps) {
     const { notify } = useContext(NotificationContext);
 
     const [selectedAge, setSelectedAge] = useState<string | undefined>();
+    const [showMap, setShowMap] = useState<boolean | undefined>(false);
 
     const editMode = mode === 'edit';
     const reviewMode = mode === 'review';
@@ -211,6 +212,10 @@ function FigureInput(props: FigureInputProps) {
             variant: 'success',
         });
     }, [onValueChange, value, notify]);
+
+    const handleShowMapAction = React.useCallback(() => {
+        setShowMap(!showMap);
+    }, [showMap]);
 
     const {
         onValueChange: onAgeChange,
@@ -325,6 +330,16 @@ function FigureInput(props: FigureInputProps) {
                 />
             </Row>
             {value.country && (
+                <div className={styles.showMapButton}>
+                    <Button
+                        name={undefined}
+                        onClick={handleShowMapAction}
+                    >
+                        {showMap ? 'Hide Map' : 'Show Map'}
+                    </Button>
+                </div>
+            )}
+            {value.country && showMap && (
                 <Row>
                     <GeoInput
                         className={styles.geoInput}

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useContext, useMemo } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useContext, useMemo } from 'react';
 import {
     NumberInput,
     DateInput,
@@ -199,7 +199,7 @@ function FigureInput(props: FigureInputProps) {
 
     const onValueChange = useFormObject(index, onChange, defaultValue);
 
-    const handleAgeAdd = React.useCallback(() => {
+    const handleAgeAdd = useCallback(() => {
         const uuid = uuidv4();
         const newAge: PartialForm<AgeFormProps> = { uuid };
         setSelectedAge(newAge.uuid);
@@ -213,9 +213,9 @@ function FigureInput(props: FigureInputProps) {
         });
     }, [onValueChange, value, notify]);
 
-    const handleShowMapAction = React.useCallback(() => {
-        setShowMap(!showMap);
-    }, [showMap]);
+    const handleShowMapAction = useCallback(() => {
+        setShowMap((oldValue) => !oldValue);
+    }, []);
 
     const {
         onValueChange: onAgeChange,

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -164,7 +164,7 @@ function FigureInput(props: FigureInputProps) {
     const { notify } = useContext(NotificationContext);
 
     const [selectedAge, setSelectedAge] = useState<string | undefined>();
-    const [showMap, setShowMap] = useState<boolean | undefined>(false);
+    const [mapShown, setMapShown] = useState<boolean | undefined>(false);
 
     const editMode = mode === 'edit';
     const reviewMode = mode === 'review';
@@ -195,9 +195,15 @@ function FigureInput(props: FigureInputProps) {
 
     const households = [householdData?.householdSize].filter(isDefined);
 
-    // const figureOptionsDisabled = figureOptionsLoading || !!figureOptionsError;
-
     const onValueChange = useFormObject(index, onChange, defaultValue);
+
+    const handleCountryChange = useCallback(
+        (countryValue: string | undefined, countryName: 'country') => {
+            setMapShown(true);
+            onValueChange(countryValue, countryName);
+        },
+        [onValueChange],
+    );
 
     const handleAgeAdd = useCallback(() => {
         const uuid = uuidv4();
@@ -214,7 +220,7 @@ function FigureInput(props: FigureInputProps) {
     }, [onValueChange, value, notify]);
 
     const handleShowMapAction = useCallback(() => {
-        setShowMap((oldValue) => !oldValue);
+        setMapShown((oldValue) => !oldValue);
     }, []);
 
     const {
@@ -315,9 +321,9 @@ function FigureInput(props: FigureInputProps) {
                     value={value.country}
                     keySelector={countryKeySelector}
                     labelSelector={countryLabelSelector}
-                    onChange={onValueChange}
+                    onChange={handleCountryChange}
                     disabled={disabled}
-                    // Disable changing country when there are more than one geolocation
+                    // NOTE: Disable changing country when there are more than one geolocation
                     readOnly={!editMode || (value.geoLocations?.length ?? 0) > 0}
                     nonClearable
                     icons={trafficLightShown && review && (
@@ -327,19 +333,19 @@ function FigureInput(props: FigureInputProps) {
                             {...getFigureReviewProps(review, figureId, 'country')}
                         />
                     )}
+                    actions={value.country && (
+                        <Button
+                            name={undefined}
+                            onClick={handleShowMapAction}
+                            compact
+                            transparent
+                        >
+                            {mapShown ? 'Hide Map' : 'Show Map'}
+                        </Button>
+                    )}
                 />
             </Row>
-            {value.country && (
-                <div className={styles.showMapButton}>
-                    <Button
-                        name={undefined}
-                        onClick={handleShowMapAction}
-                    >
-                        {showMap ? 'Hide Map' : 'Show Map'}
-                    </Button>
-                </div>
-            )}
-            {value.country && showMap && (
+            {value.country && mapShown && (
                 <Row>
                     <GeoInput
                         className={styles.geoInput}
@@ -400,6 +406,143 @@ function FigureInput(props: FigureInputProps) {
                         />
                     )}
                 />
+                <SelectInput
+                    options={roleOptions}
+                    keySelector={enumKeySelector}
+                    labelSelector={enumLabelSelector}
+                    label="Role *"
+                    name="role"
+                    value={value.role}
+                    onChange={onValueChange}
+                    error={error?.fields?.role}
+                    disabled={disabled || figureOptionsDisabled}
+                    readOnly={!editMode}
+                    icons={trafficLightShown && review && (
+                        <TrafficLightInput
+                            disabled={!reviewMode}
+                            onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'role')}
+                        />
+                    )}
+                />
+                <SelectInput
+                    options={termOptions}
+                    keySelector={basicEntityKeySelector}
+                    labelSelector={basicEntityLabelSelector}
+                    label="Term *"
+                    name="term"
+                    value={value.term}
+                    onChange={onValueChange}
+                    error={error?.fields?.term}
+                    disabled={disabled || figureOptionsDisabled}
+                    readOnly={!editMode}
+                    icons={trafficLightShown && review && (
+                        <TrafficLightInput
+                            disabled={!reviewMode}
+                            onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'term')}
+                        />
+                    )}
+                />
+                {showDisplacementOccurred && (
+                    <SelectInput
+                        options={displacementOptions}
+                        keySelector={enumKeySelector}
+                        labelSelector={enumLabelSelector}
+                        label="Displacement Occurred"
+                        name="displacementOccurred"
+                        value={value.displacementOccurred}
+                        onChange={onValueChange}
+                        error={error?.fields?.displacementOccurred}
+                        readOnly={!editMode}
+                        icons={trafficLightShown && review && (
+                            <TrafficLightInput
+                                disabled={!reviewMode}
+                                onChange={onReviewChange}
+                                {...getFigureReviewProps(review, figureId, 'displacementOccurred')}
+                            />
+                        )}
+                    />
+                )}
+            </Row>
+            <Row>
+                <SelectInput
+                    options={quantifierOptions}
+                    keySelector={enumKeySelector}
+                    labelSelector={enumLabelSelector}
+                    label="Quantifier *"
+                    name="quantifier"
+                    value={value.quantifier}
+                    onChange={onValueChange}
+                    error={error?.fields?.quantifier}
+                    disabled={disabled || figureOptionsDisabled}
+                    readOnly={!editMode}
+                    icons={trafficLightShown && review && (
+                        <TrafficLightInput
+                            disabled={!reviewMode}
+                            onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'householdSize')}
+                        />
+                    )}
+                />
+                <NumberInput
+                    label="Reported Figure *"
+                    name="reported"
+                    value={value.reported}
+                    onChange={onValueChange}
+                    error={error?.fields?.reported}
+                    disabled={disabled}
+                    readOnly={!editMode}
+                    icons={trafficLightShown && review && (
+                        <TrafficLightInput
+                            disabled={!reviewMode}
+                            onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'reported')}
+                        />
+                    )}
+                />
+                <SelectInput
+                    options={unitOptions}
+                    keySelector={enumKeySelector}
+                    labelSelector={enumLabelSelector}
+                    label="Unit *"
+                    name="unit"
+                    value={value.unit}
+                    onChange={onValueChange}
+                    error={error?.fields?.unit}
+                    disabled={disabled || figureOptionsDisabled}
+                    readOnly={!editMode}
+                    icons={trafficLightShown && review && (
+                        <TrafficLightInput
+                            disabled={!reviewMode}
+                            onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'unit')}
+                        />
+                    )}
+                />
+                {value.unit === household && (
+                    <>
+                        <NumberInput
+                            label="Household Size *"
+                            name="householdSize"
+                            value={value.householdSize}
+                            onChange={onValueChange}
+                            error={error?.fields?.householdSize}
+                            disabled={disabled}
+                            readOnly={!editMode}
+                            suggestions={households}
+                            suggestionKeySelector={householdKeySelector}
+                            suggestionLabelSelector={householdKeySelector}
+                        />
+                        <NumberInput
+                            label="Total Figure"
+                            name="totalFigure"
+                            value={(value.householdSize ?? 0) * (value.reported ?? 0)}
+                            disabled={disabled}
+                            readOnly
+                        />
+                    </>
+                )}
             </Row>
             <Row>
                 <DateInput
@@ -475,169 +618,28 @@ function FigureInput(props: FigureInputProps) {
                     />
                 )}
             </Row>
-            <Row>
-                <SelectInput
-                    options={quantifierOptions}
-                    keySelector={enumKeySelector}
-                    labelSelector={enumLabelSelector}
-                    label="Quantifier *"
-                    name="quantifier"
-                    value={value.quantifier}
-                    onChange={onValueChange}
-                    error={error?.fields?.quantifier}
-                    disabled={disabled || figureOptionsDisabled}
-                    readOnly={!editMode}
-                    icons={trafficLightShown && review && (
+            {showHousingToggle && (
+                <Row>
+                    {trafficLightShown && review && (
                         <TrafficLightInput
                             disabled={!reviewMode}
+                            className={styles.trafficLight}
                             onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'householdSize')}
+                            {...getFigureReviewProps(review, figureId, 'isHousingDestruction')}
                         />
                     )}
-                />
-                <NumberInput
-                    label="Reported Figure *"
-                    name="reported"
-                    value={value.reported}
-                    onChange={onValueChange}
-                    error={error?.fields?.reported}
-                    disabled={disabled}
-                    readOnly={!editMode}
-                    icons={trafficLightShown && review && (
-                        <TrafficLightInput
-                            disabled={!reviewMode}
-                            onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'reported')}
-                        />
-                    )}
-                />
-                <SelectInput
-                    options={unitOptions}
-                    keySelector={enumKeySelector}
-                    labelSelector={enumLabelSelector}
-                    label="Unit *"
-                    name="unit"
-                    value={value.unit}
-                    onChange={onValueChange}
-                    error={error?.fields?.unit}
-                    disabled={disabled || figureOptionsDisabled}
-                    readOnly={!editMode}
-                    icons={trafficLightShown && review && (
-                        <TrafficLightInput
-                            disabled={!reviewMode}
-                            onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'unit')}
-                        />
-                    )}
-                />
-            </Row>
-            <Row>
-                {value.unit === household && (
-                    <>
-                        <NumberInput
-                            label="Household Size *"
-                            name="householdSize"
-                            value={value.householdSize}
-                            onChange={onValueChange}
-                            error={error?.fields?.householdSize}
-                            disabled={disabled}
-                            readOnly={!editMode}
-                            suggestions={households}
-                            suggestionKeySelector={householdKeySelector}
-                            suggestionLabelSelector={householdKeySelector}
-                        />
-                        <NumberInput
-                            label="Total Figure"
-                            name="totalFigure"
-                            value={(value.householdSize ?? 0) * (value.reported ?? 0)}
-                            disabled={disabled}
-                            readOnly
-                        />
-                    </>
-                )}
-                <SelectInput
-                    options={termOptions}
-                    keySelector={basicEntityKeySelector}
-                    labelSelector={basicEntityLabelSelector}
-                    label="Term *"
-                    name="term"
-                    value={value.term}
-                    onChange={onValueChange}
-                    error={error?.fields?.term}
-                    disabled={disabled || figureOptionsDisabled}
-                    readOnly={!editMode}
-                    icons={trafficLightShown && review && (
-                        <TrafficLightInput
-                            disabled={!reviewMode}
-                            onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'term')}
-                        />
-                    )}
-                />
-                {showDisplacementOccurred && (
-                    <SelectInput
-                        options={displacementOptions}
-                        keySelector={enumKeySelector}
-                        labelSelector={enumLabelSelector}
-                        label="Displacement Occurred"
-                        name="displacementOccurred"
-                        value={value.displacementOccurred}
+                    <Switch
+                        label="Housing destruction (recommended estimate for this entry)"
+                        name="isHousingDestruction"
+                        // FIXME: typings of toggle-ui
+                        value={value.isHousingDestruction}
                         onChange={onValueChange}
-                        error={error?.fields?.displacementOccurred}
+                        // error={error?.fields?.isHousingDestruction}
+                        disabled={disabled}
                         readOnly={!editMode}
-                        icons={trafficLightShown && review && (
-                            <TrafficLightInput
-                                disabled={!reviewMode}
-                                onChange={onReviewChange}
-                                {...getFigureReviewProps(review, figureId, 'displacementOccurred')}
-                            />
-                        )}
                     />
-                )}
-                <SelectInput
-                    options={roleOptions}
-                    keySelector={enumKeySelector}
-                    labelSelector={enumLabelSelector}
-                    label="Role *"
-                    name="role"
-                    value={value.role}
-                    onChange={onValueChange}
-                    error={error?.fields?.role}
-                    disabled={disabled || figureOptionsDisabled}
-                    readOnly={!editMode}
-                    icons={trafficLightShown && review && (
-                        <TrafficLightInput
-                            disabled={!reviewMode}
-                            onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'role')}
-                        />
-                    )}
-                />
-            </Row>
-            <Row>
-                {showHousingToggle && (
-                    <>
-                        {trafficLightShown && review && (
-                            <TrafficLightInput
-                                disabled={!reviewMode}
-                                className={styles.trafficLight}
-                                onChange={onReviewChange}
-                                {...getFigureReviewProps(review, figureId, 'isHousingDestruction')}
-                            />
-                        )}
-                        <Switch
-                            label="Housing destruction (recommended estimate for this entry)"
-                            name="isHousingDestruction"
-                            // FIXME: typings of toggle-ui
-                            value={value.isHousingDestruction}
-                            onChange={onValueChange}
-                            // error={error?.fields?.isHousingDestruction}
-                            disabled={disabled}
-                            readOnly={!editMode}
-                        />
-                    </>
-                )}
-            </Row>
+                </Row>
+            )}
             <Row>
                 {trafficLightShown && review && (
                     <TrafficLightInput

--- a/src/views/Entry/EntryForm/FigureInput/styles.css
+++ b/src/views/Entry/EntryForm/FigureInput/styles.css
@@ -23,3 +23,9 @@
 .geo-input {
     height: 300px;
 }
+
+.show-map-button {
+    display: flex;
+    justify-content: right;
+    padding: var(--spacing-medium);
+}

--- a/src/views/Entry/EntryForm/GeoLocationInput/index.tsx
+++ b/src/views/Entry/EntryForm/GeoLocationInput/index.tsx
@@ -110,8 +110,6 @@ function GeoLocationInput(props: GeoLocationInputProps) {
                     disabled={disabled}
                     readOnly
                 />
-            </Row>
-            <Row>
                 <SelectInput
                     label="Type *"
                     name="identifier"

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -9,9 +9,8 @@ import {
     Button,
     Modal,
 } from '@togglecorp/toggle-ui';
-import MarkdownView from 'react-showdown';
 
-import { markdownOptions } from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import DomainContext from '#components/DomainContext';
 import Container from '#components/Container';
 import TextBlock from '#components/TextBlock';
@@ -273,9 +272,8 @@ function Event(props: EventProps) {
                 className={styles.container}
                 heading="Narrative"
             >
-                <MarkdownView
+                <MarkdownPreview
                     markdown={eventData?.event?.eventNarrative ?? 'Narrative not available'}
-                    options={markdownOptions}
                 />
             </Container>
             <EntriesTable

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -302,12 +302,6 @@ function ReportFigureTable(props: ReportFigureProps) {
                 (item) => item.role,
                 { sortable: true },
             ),
-            createTextColumn<ReportFigureFields, string>(
-                'category__name',
-                'Figure Type',
-                (item) => item.category?.name,
-                { sortable: true },
-            ),
             createLinkColumn<ReportFigureFields, string>(
                 'category__name',
                 'Figure Type',

--- a/src/views/Report/index.tsx
+++ b/src/views/Report/index.tsx
@@ -46,7 +46,7 @@ import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
 import UserItem from '#components/UserItem';
 import NumberBlock from '#components/NumberBlock';
-import MarkdownEditor from '#components/MarkdownEditor';
+import { MarkdownPreview } from '#components/MarkdownEditor';
 import ReportSelectInput, { ReportOption } from '#components/selections/ReportSelectInput';
 import { reverseRoute } from '#hooks/useRouteMatching';
 import route from '#config/routes';
@@ -821,10 +821,8 @@ function Report(props: ReportProps) {
                             </QuickActionButton>
                         )}
                     >
-                        <MarkdownEditor
-                            value={analysis ?? 'N/a'}
-                            name="analysis"
-                            readOnly
+                        <MarkdownPreview
+                            markdown={analysis || 'N/a'}
                         />
                     </Container>
                     <Container
@@ -841,10 +839,8 @@ function Report(props: ReportProps) {
                             </QuickActionButton>
                         )}
                     >
-                        <MarkdownEditor
-                            value={methodology ?? 'N/a'}
-                            name="methodology"
-                            readOnly
+                        <MarkdownPreview
+                            markdown={methodology || 'N/a'}
                         />
                     </Container>
                     <Container
@@ -861,10 +857,8 @@ function Report(props: ReportProps) {
                             </QuickActionButton>
                         )}
                     >
-                        <MarkdownEditor
-                            value={challenges ?? 'N/a'}
-                            name="challenges"
-                            readOnly
+                        <MarkdownPreview
+                            markdown={challenges || 'N/a'}
                         />
                     </Container>
                     <Container
@@ -881,10 +875,8 @@ function Report(props: ReportProps) {
                             </QuickActionButton>
                         )}
                     >
-                        <MarkdownEditor
-                            value={significantUpdates ?? 'N/a'}
-                            name="significantUpdates"
-                            readOnly
+                        <MarkdownPreview
+                            markdown={significantUpdates || 'N/a'}
                         />
                     </Container>
                     <Container
@@ -901,10 +893,8 @@ function Report(props: ReportProps) {
                             </QuickActionButton>
                         )}
                     >
-                        <MarkdownEditor
-                            value={summary ?? 'N/a'}
-                            name="summary"
-                            readOnly
+                        <MarkdownPreview
+                            markdown={summary || 'N/a'}
                         />
                     </Container>
                 </div>


### PR DESCRIPTION
## Changes
- Add "ShowMap" button in Extraction Entry in order to render map only when the showMap button is triggered

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
