### PR TITLE
Add country column in tables of Event detail

### DIFF
--- a/src/components/tables/EntriesTable/NudeEntryTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeEntryTable/index.tsx
@@ -107,6 +107,10 @@ const ENTRY_LIST = gql`
                         id
                         name
                     }
+                    countries {
+                        id
+                        name
+                    }
                 }
                 totalStockIdpFigures(data: {
                     categories: $filterFigureCategories,
@@ -313,7 +317,13 @@ function NudeEntryTable(props: NudeEntryTableProps) {
                 createTextColumn<EntryFields, string>(
                     'event__event_type',
                     'Cause',
-                    (item) => item.event.eventType,
+                    (item) => item.event?.eventType,
+                    { sortable: true },
+                ),
+                createTextColumn<EntryFields, string>(
+                    'countries__idmc_short_name',
+                    'Country',
+                    (item) => item.event.countries.map((c) => c.name).join(''),
                     { sortable: true },
                 ),
                 createNumberColumn<EntryFields, string>(

--- a/src/components/tables/EntriesTable/NudeEntryTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeEntryTable/index.tsx
@@ -109,7 +109,7 @@ const ENTRY_LIST = gql`
                     }
                     countries {
                         id
-                        name
+                        idmcShortName
                     }
                 }
                 totalStockIdpFigures(data: {
@@ -321,9 +321,9 @@ function NudeEntryTable(props: NudeEntryTableProps) {
                     { sortable: true },
                 ),
                 createTextColumn<EntryFields, string>(
-                    'countries__idmc_short_name',
-                    'Country',
-                    (item) => item.event.countries.map((c) => c.name).join(''),
+                    'event__countries__idmc_short_name',
+                    'Countries',
+                    (item) => item.event.countries.map((c) => c.idmcShortName).join(', '),
                     { sortable: true },
                 ),
                 createNumberColumn<EntryFields, string>(

--- a/src/views/Extraction/ExtractionEntriesTable/NudeEntryTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeEntryTable/index.tsx
@@ -125,6 +125,10 @@ export const EXTRACTION_ENTRY_LIST = gql`
                         id
                         name
                     }
+                    countries {
+                        id
+                        idmcShortName
+                    }
                 }
                 totalStockIdpFigures(data: {
                     categories: $filterFigureCategories,
@@ -324,6 +328,12 @@ function NudeEntryTable(props: NudeEntryTableProps) {
                     'event__event_type',
                     'Cause',
                     (item) => item.event.eventType,
+                    { sortable: true },
+                ),
+                createTextColumn<EntryFields, string>(
+                    'event__countries__idmc_short_name',
+                    'Countries',
+                    (item) => item.event.countries.map((c) => c.idmcShortName).join(', '),
                     { sortable: true },
                 ),
                 createNumberColumn<EntryFields, string>(


### PR DESCRIPTION
## Addresses:
- https://github.com/idmc-labs/Helix2.0/issues/235

## Changes:
- Add Country column in Entries table of a particular event detail

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
