### PR TITLE
Remove entry review page

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         "workbox-webpack-plugin": "^5.1.4"
     },
     "dependencies": {
-        "@apollo/client": "3.3.6",
+        "@apollo/client": "^3.3.21",
         "@hcaptcha/react-hcaptcha": "^0.3.6",
         "@mapbox/mapbox-gl-draw": "^1.2.0",
         "@sentry/react": "^5.29.1",

--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -326,11 +326,6 @@ function Multiplexer(props: Props) {
                                     />
                                     <Route
                                         exact
-                                        path={routeSettings.entryReview.path}
-                                        render={routeSettings.entryReview.load}
-                                    />
-                                    <Route
-                                        exact
                                         path={routeSettings.newEntryFromParkedItem.path}
                                         render={routeSettings.newEntryFromParkedItem.load}
                                     />

--- a/src/Root/App/index.tsx
+++ b/src/Root/App/index.tsx
@@ -48,12 +48,9 @@ const client = new ApolloClient({
             fetchPolicy: 'network-only',
             errorPolicy: 'all',
         },
-        // NOTE: useQuery should use watchQuery
         watchQuery: {
             fetchPolicy: 'cache-and-network',
-            // NOTE: https://github.com/apollographql/apollo-client/issues/7346#issuecomment-730275343
-            // Setting nextFetchPolicy to stop duplicate queries call
-            nextFetchPolicy: 'cache-first',
+            nextFetchPolicy: 'cache-and-network',
             errorPolicy: 'all',
         },
     },

--- a/src/components/TrafficLightInput/index.tsx
+++ b/src/components/TrafficLightInput/index.tsx
@@ -4,6 +4,7 @@ import { IoAddCircleSharp } from 'react-icons/io5';
 import { Button, PopupButton } from '@togglecorp/toggle-ui';
 
 import { ReviewFields } from '#views/Entry/EntryForm/types';
+import Message from '#components/Message';
 import { Entry_Review_Status as EntryReviewStatus } from '#generated/types';
 import CommentItem from '#components/CommentItem';
 
@@ -62,42 +63,48 @@ function TrafficLightInput<N extends string>(props: TrafficLightInputProps<N>) {
             )}
             arrowHidden
         >
-            <div className={styles.buttons}>
-                <Button
-                    className={styles.good}
-                    name="GREEN"
-                    onClick={handleClick}
-                    transparent
-                    compact
-                    disabled={disabled || value === 'GREEN'}
-                >
-                    Good
-                </Button>
-                <Button
-                    name="GREY"
-                    onClick={handleClick}
-                    transparent
-                    compact
-                    disabled={disabled || value === 'GREY'}
-                >
-                    Not reviewed
-                </Button>
-                <Button
-                    className={styles.bad}
-                    name="RED"
-                    onClick={handleClick}
-                    transparent
-                    compact
-                    disabled={disabled || value === 'RED'}
-                >
-                    To be corrected
-                </Button>
-            </div>
-            {comment && (
+            {!disabled && (
+                <div className={styles.buttons}>
+                    <Button
+                        className={styles.good}
+                        name="GREEN"
+                        onClick={handleClick}
+                        transparent
+                        compact
+                        disabled={value === 'GREEN'}
+                    >
+                        Good
+                    </Button>
+                    <Button
+                        name="GREY"
+                        onClick={handleClick}
+                        transparent
+                        compact
+                        disabled={value === 'GREY'}
+                    >
+                        Not reviewed
+                    </Button>
+                    <Button
+                        className={styles.bad}
+                        name="RED"
+                        onClick={handleClick}
+                        transparent
+                        compact
+                        disabled={value === 'RED'}
+                    >
+                        To be corrected
+                    </Button>
+                </div>
+            )}
+            {comment ? (
                 <CommentItem
                     comment={comment}
                     deleteDisabled
                     editDisabled
+                />
+            ) : (
+                <Message
+                    message="No comment found."
                 />
             )}
         </PopupButton>

--- a/src/components/tables/EntriesTable/index.tsx
+++ b/src/components/tables/EntriesTable/index.tsx
@@ -35,6 +35,7 @@ interface EntriesTableProps {
     page?: number;
     pageSize?: number;
     pagerDisabled?: boolean;
+    pagerPageControlDisabled?: boolean;
 
     className?: string;
     eventColumnHidden?: boolean;
@@ -52,6 +53,7 @@ function EntriesTable(props: EntriesTableProps) {
         page: pageFromProps,
         pageSize: pageSizeFromProps,
         pagerDisabled,
+        pagerPageControlDisabled,
         className,
         eventColumnHidden,
         crisisColumnHidden,
@@ -173,6 +175,7 @@ function EntriesTable(props: EntriesTableProps) {
                                 maxItemsPerPage={entriesPageSize}
                                 onActivePageChange={setEntriesPage}
                                 onItemsPerPageChange={setEntriesPageSize}
+                                itemsPerPageControlHidden={pagerPageControlDisabled}
                             />
                         )}
                         {selectedTab === 'Figures' && (
@@ -182,6 +185,7 @@ function EntriesTable(props: EntriesTableProps) {
                                 maxItemsPerPage={figuresPageSize}
                                 onActivePageChange={setFiguresPage}
                                 onItemsPerPageChange={setFiguresPageSize}
+                                itemsPerPageControlHidden={pagerPageControlDisabled}
                             />
                         )}
                     </>

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -131,14 +131,6 @@ const routeSettings = {
         visibility: 'is-authenticated',
         checkPermissions: (permissions) => permissions.entry?.add,
     }),
-    entryView: wrap({
-        path: '/entries/:entryId(\\d+)/',
-        title: 'View Entry',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: { mode: 'view' },
-        visibility: 'is-authenticated',
-    }),
     entryEdit: wrap({
         path: '/entries/:entryId(\\d+)/edit/',
         title: 'Edit Entry',
@@ -148,15 +140,6 @@ const routeSettings = {
         visibility: 'is-authenticated',
         checkPermissions: (permissions) => permissions.entry?.change,
     }),
-    entryReview: wrap({
-        path: '/entries/:entryId(\\d+)/review/',
-        title: 'Review Entry',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: { mode: 'review' },
-        visibility: 'is-authenticated',
-        checkPermissions: (permissions) => permissions.review?.add,
-    }),
     newEntryFromParkedItem: wrap({
         path: '/entries/new-from-parked-item/:parkedItemId(\\d+)/',
         title: 'New Entry from Parking Lot',
@@ -165,6 +148,14 @@ const routeSettings = {
         componentProps: { mode: 'edit' },
         visibility: 'is-authenticated',
         checkPermissions: (permissions) => permissions.entry?.add,
+    }),
+    entryView: wrap({
+        path: '/entries/:entryId(\\d+)/',
+        title: 'View Entry',
+        navbarVisibility: true,
+        component: lazy(() => import('../views/Entry')),
+        componentProps: { mode: 'review' },
+        visibility: 'is-authenticated',
     }),
     reports: wrap({
         path: '/reports/',

--- a/src/views/Dashboard/EntriesForReview/index.tsx
+++ b/src/views/Dashboard/EntriesForReview/index.tsx
@@ -151,7 +151,7 @@ function EntriesForReview(props: EntriesForReviewProps) {
                 },
                 cellRenderer: ActionCell,
                 cellRendererParams: (_, datum) => ({
-                    viewLinkRoute: route.entryReview,
+                    viewLinkRoute: route.entryView,
                     viewLinkAttrs: { entryId: datum.entry.id },
                 }),
             };

--- a/src/views/Entry/EntryComments/CommentForm/index.tsx
+++ b/src/views/Entry/EntryComments/CommentForm/index.tsx
@@ -93,9 +93,9 @@ const defaultFormValues: PartialForm<FormType> = {};
 
 interface CommentFormProps {
     id?: string;
-    onCommentFormCancel?: () => void;
+    onCancel?: () => void;
+    onSuccess?: () => void;
     entry: string;
-    onCommentCreate?: () => void;
     clearable?: boolean;
     cancelable?: boolean;
     minimal?: boolean;
@@ -104,9 +104,9 @@ interface CommentFormProps {
 function CommentForm(props: CommentFormProps) {
     const {
         id,
-        onCommentFormCancel,
+        onCancel,
         entry,
-        onCommentCreate,
+        onSuccess,
         clearable,
         cancelable,
         minimal,
@@ -164,7 +164,7 @@ function CommentForm(props: CommentFormProps) {
     >(
         CREATE_COMMENT,
         {
-            update: onCommentCreate,
+            update: onSuccess,
             onCompleted: (response) => {
                 const { createComment: createCommentRes } = response;
                 if (!createCommentRes) {
@@ -220,8 +220,8 @@ function CommentForm(props: CommentFormProps) {
                         variant: 'success',
                     });
                     clearForm();
-                    if (onCommentFormCancel) {
-                        onCommentFormCancel();
+                    if (onCancel) {
+                        onCancel();
                     }
                 }
             },
@@ -289,7 +289,7 @@ function CommentForm(props: CommentFormProps) {
                     {cancelable && (
                         <Button
                             name={undefined}
-                            onClick={onCommentFormCancel}
+                            onClick={onCancel}
                             disabled={loading}
                         >
                             Cancel
@@ -299,7 +299,7 @@ function CommentForm(props: CommentFormProps) {
                         name={undefined}
                         variant="primary"
                         type="submit"
-                        disabled={pristine || loading || !value.body}
+                        disabled={pristine || loading}
                     >
                         Submit
                     </Button>

--- a/src/views/Entry/EntryComments/ReviewCommentForm/index.tsx
+++ b/src/views/Entry/EntryComments/ReviewCommentForm/index.tsx
@@ -1,0 +1,254 @@
+import React, { useCallback, useContext, useMemo } from 'react';
+import {
+    TextArea,
+    Button,
+} from '@togglecorp/toggle-ui';
+import { isDefined } from '@togglecorp/fujs';
+import { gql, useMutation } from '@apollo/client';
+import {
+    removeNull,
+    ObjectSchema,
+    useForm,
+    createSubmitHandler,
+    requiredStringCondition,
+    idCondition,
+    PartialForm,
+    PurgeNull,
+} from '@togglecorp/toggle-form';
+
+import { transformToFormError } from '#utils/errorTransform';
+
+import Loading from '#components/Loading';
+import FormActions from '#components/FormActions';
+import NonFieldError from '#components/NonFieldError';
+import NotificationContext from '#components/NotificationContext';
+
+import { WithId } from '#utils/common';
+import {
+    CreateReviewCommentMutation,
+    CreateReviewCommentMutationVariables,
+} from '#generated/types';
+
+import { getReviewInputMap, getReviewList } from '../../EntryForm/utils';
+import { ReviewInputFields } from '../../EntryForm/types';
+import styles from './styles.css';
+
+export const CREATE_REVIEW_COMMENT = gql`
+    mutation CreateReviewComment($data: ReviewCommentCreateInputType!){
+        createReviewComment(data: $data) {
+            ok
+            result {
+                entry {
+                    id
+                    latestReviews {
+                        ageId
+                        field
+                        id
+                        figure {
+                            id
+                        }
+                        geoLocation {
+                            id
+                        }
+                        value
+                        comment {
+                            body
+                            id
+                            createdAt
+                            createdBy {
+                                id
+                                fullName
+                            }
+                        }
+                    }
+                    reviewing {
+                        id
+                        status
+                        createdAt
+                        reviewer {
+                            id
+                            fullName
+                        }
+                    }
+                }
+            }
+            errors
+        }
+    }
+`;
+
+type CommentFormFields = CreateReviewCommentMutationVariables['data'];
+type FormType = PurgeNull<PartialForm<WithId<CommentFormFields>>>;
+type FormSchema = ObjectSchema<FormType>;
+type FormSchemaFields = ReturnType<FormSchema['fields']>;
+
+const schema: FormSchema = {
+    fields: (): FormSchemaFields => ({
+        id: [idCondition],
+        body: [requiredStringCondition],
+    }),
+};
+
+const defaultFormValues: PartialForm<FormType> = {};
+
+interface CommentFormProps {
+    entry: string;
+    onSuccess: (value: ReviewInputFields) => void;
+    review: ReviewInputFields,
+}
+
+function CommentForm(props: CommentFormProps) {
+    const {
+        entry,
+        onSuccess,
+
+        review,
+    } = props;
+
+    const dirtyReviews = useMemo(
+        () => (
+            Object.values(review)
+                .filter(isDefined)
+                .filter((item) => item.dirty)
+        ),
+        [review],
+    );
+
+    const {
+        value,
+        error,
+        onValueChange,
+        onErrorSet,
+        validate,
+    } = useForm(defaultFormValues, schema);
+
+    const {
+        notify,
+        notifyGQLError,
+    } = useContext(NotificationContext);
+
+    const clearForm = useCallback(() => {
+        onValueChange(undefined, 'body' as const);
+    }, [onValueChange]);
+
+    const [
+        createReviewComment,
+        { loading: createCommentLoading },
+    ] = useMutation<
+        CreateReviewCommentMutation,
+        CreateReviewCommentMutationVariables
+    >(
+        CREATE_REVIEW_COMMENT,
+        {
+            onCompleted: (response) => {
+                const { createReviewComment: createReviewCommentRes } = response;
+                if (!createReviewCommentRes) {
+                    return;
+                }
+
+                const { errors, result } = createReviewCommentRes;
+
+                if (errors) {
+                    const createCommentError = transformToFormError(removeNull(errors));
+                    onErrorSet(createCommentError);
+                    notifyGQLError(errors);
+                }
+                if (result) {
+                    const { entry: resEntry } = removeNull(result);
+                    const prevReview = getReviewInputMap(
+                        // FIXME: filtering by isDefined should not be necessary
+                        resEntry?.latestReviews?.filter(isDefined).map((r) => ({
+                            field: r.field,
+                            figure: r.figure?.id,
+                            geoLocation: r.geoLocation?.id,
+                            ageId: r.ageId,
+                            value: r.value,
+                            comment: r.comment,
+                        })),
+                    );
+                    notify({
+                        children: 'Comment created successfully!',
+                        variant: 'success',
+                    });
+                    clearForm();
+                    onSuccess(prevReview);
+                }
+            },
+            onError: (errors) => {
+                notify({
+                    children: errors.message,
+                    variant: 'error',
+                });
+                onErrorSet({
+                    $internal: errors.message,
+                });
+            },
+        },
+    );
+
+    const handleSubmit = useCallback((finalValue: FormType) => {
+        const reviewList = getReviewList(dirtyReviews);
+        // FIXME: call handler so that comments can be re-fetched or do that refetching manually
+        createReviewComment({
+            variables: {
+                data: {
+                    body: finalValue.body,
+                    entry,
+                    reviews: reviewList.map((r) => ({
+                        field: r.field,
+                        figure: r.figure,
+                        geoLocation: r.geoLocation,
+                        ageId: r.ageId,
+                        value: r.value,
+                        entry,
+                    })),
+                },
+            },
+        });
+    }, [createReviewComment, entry, dirtyReviews]);
+
+    const loading = createCommentLoading;
+
+    return (
+        <form
+            className={styles.commentForm}
+            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+        >
+            {loading && <Loading absolute />}
+            <NonFieldError>
+                {error?.$internal}
+            </NonFieldError>
+            <TextArea
+                label="Review Comment *"
+                name="body"
+                onChange={onValueChange}
+                value={value.body}
+                disabled={loading}
+                placeholder="Leave your comment here"
+            />
+            <FormActions className={styles.actions}>
+                <Button
+                    name={undefined}
+                    onClick={clearForm}
+                    disabled={loading || !value.body}
+                >
+                    Clear
+                </Button>
+                <Button
+                    name={undefined}
+                    variant="primary"
+                    type="submit"
+                    disabled={loading}
+                >
+                    {
+                        dirtyReviews.length > 0
+                            ? `Submit (${dirtyReviews.length})`
+                            : 'Submit'
+                    }
+                </Button>
+            </FormActions>
+        </form>
+    );
+}
+
+export default CommentForm;

--- a/src/views/Entry/EntryComments/ReviewCommentForm/styles.css
+++ b/src/views/Entry/EntryComments/ReviewCommentForm/styles.css
@@ -1,0 +1,7 @@
+.comment-form {
+    position: relative;
+
+    .actions {
+        margin-top: var(--spacing-large);
+    }
+}

--- a/src/views/Entry/EntryForm/DetailsInput/index.tsx
+++ b/src/views/Entry/EntryForm/DetailsInput/index.tsx
@@ -334,7 +334,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
                             disabled={!reviewMode}
                             name="sources"
                             value={review.sources?.value}
-                            comment={review.publishDate?.comment}
+                            comment={review.sources?.comment}
                             onChange={onReviewChange}
                         />
                     )}
@@ -357,7 +357,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
                             disabled={!reviewMode}
                             name="publishers"
                             value={review.publishers?.value}
-                            comment={review.publishDate?.comment}
+                            comment={review.publishers?.comment}
                             onChange={onReviewChange}
                         />
                     )}

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -108,7 +108,7 @@ type HouseholdSize = NonNullable<HouseholdSizeQuery['householdSize']>;
 const householdKeySelector = (item: HouseholdSize) => String(item.size);
 
 const defaultValue: FigureInputValue = {
-    uuid: 'hari',
+    uuid: 'random',
 };
 
 interface FigureInputProps {
@@ -412,11 +412,8 @@ function FigureInput(props: FigureInputProps) {
                     icons={trafficLightShown && review && (
                         <TrafficLightInput
                             disabled={!reviewMode}
-                            className={styles.trafficLight}
-                            name="calculationLogic"
-                            value={review.calculationLogic?.value}
-                            comment={review.calculationLogic?.comment}
                             onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'calculationLogic')}
                         />
                     )}
                 />
@@ -433,11 +430,8 @@ function FigureInput(props: FigureInputProps) {
                     icons={trafficLightShown && review && (
                         <TrafficLightInput
                             disabled={!reviewMode}
-                            className={styles.trafficLight}
-                            name="caveats"
-                            value={review.caveats?.value}
-                            comment={review.caveats?.comment}
                             onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'caveats')}
                         />
                     )}
                 />
@@ -454,10 +448,8 @@ function FigureInput(props: FigureInputProps) {
                     icons={trafficLightShown && review && (
                         <TrafficLightInput
                             disabled={!reviewMode}
-                            name="sourceExcerpt"
-                            value={review.sourceExcerpt?.value}
-                            comment={review.publishDate?.comment}
                             onChange={onReviewChange}
+                            {...getFigureReviewProps(review, figureId, 'sourceExcerpt')}
                         />
                     )}
                 />
@@ -573,7 +565,7 @@ function FigureInput(props: FigureInputProps) {
                         <TrafficLightInput
                             disabled={!reviewMode}
                             onChange={onReviewChange}
-                            {...getFigureReviewProps(review, figureId, 'householdSize')}
+                            {...getFigureReviewProps(review, figureId, 'quantifier')}
                         />
                     )}
                 />

--- a/src/views/Entry/EntryForm/queries.tsx
+++ b/src/views/Entry/EntryForm/queries.tsx
@@ -250,50 +250,6 @@ export const UPDATE_ENTRY = gql`
     }
 `;
 
-export const CREATE_REVIEW_COMMENT = gql`
-    mutation CreateReviewComment($data: ReviewCommentCreateInputType!){
-        createReviewComment(data: $data) {
-            ok
-            result {
-                entry {
-                    id
-                    latestReviews {
-                        ageId
-                        field
-                        id
-                        figure {
-                            id
-                        }
-                        geoLocation {
-                            id
-                        }
-                        value
-                        comment {
-                            body
-                            id
-                            createdAt
-                            createdBy {
-                                id
-                                fullName
-                            }
-                        }
-                    }
-                    reviewing {
-                        id
-                        status
-                        createdAt
-                        reviewer {
-                            id
-                            fullName
-                        }
-                    }
-                }
-            }
-            errors
-        }
-    }
-`;
-
 export const FIGURE_OPTIONS = gql`
     query FigureOptionsForEntryForm {
         quantifierList: __type(name: "QUANTIFIER") {

--- a/src/views/Entry/EntryForm/styles.css
+++ b/src/views/Entry/EntryForm/styles.css
@@ -1,16 +1,3 @@
-.popup {
-    padding: calc(var(--spacing-medium) - var(--spacing-small));
-    width: 400px;
-
-    .comment {
-        margin: var(--spacing-small);
-    }
-
-    .popup-content {
-        display: flex;
-    }
-}
-
 .entry-form {
     display: flex;
     position: relative;

--- a/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
+++ b/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
@@ -384,7 +384,7 @@ function OrganizationForm(props: OrganizationFormProps) {
                     disabled={disabled || organizationKindsLoading || !!organizationKindsError}
                 />
                 <SelectInput
-                    label="Category *"
+                    label="Geographical Coverage *"
                     name="category"
                     options={organizationCategoryList}
                     value={value.category}

--- a/src/views/Organizations/OrganizationTable/index.tsx
+++ b/src/views/Organizations/OrganizationTable/index.tsx
@@ -273,7 +273,7 @@ function OrganizationTable(props: OrganizationProps) {
             ),
             createTextColumn<OrganizationFields, string>(
                 'category',
-                'Category',
+                'Geographical Coverage',
                 (item) => item.category,
                 { sortable: true },
             ),

--- a/src/views/Reports/ReportForm/index.tsx
+++ b/src/views/Reports/ReportForm/index.tsx
@@ -563,7 +563,6 @@ function ReportForm(props: ReportFormProps) {
                 />
                 {conflictType && (
                     <MultiSelectInput
-                        className={styles.input}
                         options={violenceOptions}
                         keySelector={basicEntityKeySelector}
                         labelSelector={basicEntityLabelSelector}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,25 +2,6 @@
 # yarn lockfile v1
 
 
-"@apollo/client@3.3.6":
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.6.tgz#f359646308167f38d5bc498dfc2344c888400093"
-  integrity sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.0.0"
-    "@types/zen-observable" "^0.8.0"
-    "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.11.0"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.13.1"
-    prop-types "^15.7.2"
-    symbol-observable "^2.0.0"
-    ts-invariant "^0.6.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.14"
-
 "@apollo/client@^3.1.3", "@apollo/client@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.5.tgz#24e0a6faa1d231ab44807af237c6227410c75c4d"
@@ -39,6 +20,24 @@
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
     zen-observable "^0.8.14"
+
+"@apollo/client@^3.3.21":
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.16.tgz#67090d5655aa843fa64d26f1913315e384a5fa0f"
+  integrity sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.3"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.9.0"
+    tslib "^2.3.0"
+    zen-observable-ts "~1.1.0"
 
 "@apollo/federation@0.20.7":
   version "0.20.7"
@@ -4135,11 +4134,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/ungap__global-this@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"
-  integrity sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==
-
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -4199,6 +4193,11 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+
+"@types/zen-observable@0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
+  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^4.12.0":
   version "4.12.0"
@@ -4269,11 +4268,6 @@
   dependencies:
     "@typescript-eslint/types" "4.12.0"
     eslint-visitor-keys "^2.0.0"
-
-"@ungap/global-this@^0.4.2":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@ungap/global-this/-/global-this-0.4.3.tgz#44cb668b03e7c4bc88cb6e6f9329d381131878ee"
-  integrity sha512-MuHEpDBurNVeD6mV9xBcAN2wfTwuaFQhHuhWkJuXmyVJ5P5sBCw+nnFpdfb0tAvgWkfefWCsAoAsh7MTUr3LPg==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4427,6 +4421,13 @@
   dependencies:
     tslib "^1.9.3"
 
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
 "@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
@@ -4441,12 +4442,19 @@
   dependencies:
     tslib "^1.9.3"
 
-"@wry/equality@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.0.tgz#4b022a0907f01f32c07a1a665d9430155a59ea06"
-  integrity sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==
+"@wry/equality@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
+  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -9325,6 +9333,13 @@ graphql-tag@2.11.0, graphql-tag@^2.10.1, graphql-tag@^2.11.0:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
   integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
+graphql-tag@^2.12.3:
+  version "2.12.5"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
+  integrity sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==
+  dependencies:
+    tslib "^2.1.0"
+
 "graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0":
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
@@ -12698,12 +12713,13 @@ optimism@^0.13.0:
   dependencies:
     "@wry/context" "^0.5.2"
 
-optimism@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.1.tgz#df2e6102c973f870d6071712fffe4866bb240384"
-  integrity sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
   dependencies:
-    "@wry/context" "^0.5.2"
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
 
 optimize-css-assets-webpack-plugin@^5.0.4:
   version "5.0.4"
@@ -16156,6 +16172,11 @@ symbol-observable@^2.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
   integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -16503,14 +16524,12 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   dependencies:
     tslib "^1.9.3"
 
-ts-invariant@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.6.0.tgz#44066ecfeb7a806ff1c3b0b283408a337a885412"
-  integrity sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==
+ts-invariant@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
+  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
   dependencies:
-    "@types/ungap__global-this" "^0.3.1"
-    "@ungap/global-this" "^0.4.2"
-    tslib "^1.9.3"
+    tslib "^2.1.0"
 
 ts-log@^2.2.3:
   version "2.2.3"
@@ -16563,6 +16582,11 @@ tslib@^2.0.0, tslib@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tslib@^2.1.0, tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -17900,7 +17924,15 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0, zen-observable@^0.8.14:
+zen-observable-ts@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
+  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+  dependencies:
+    "@types/zen-observable" "0.8.3"
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15, zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
- Rename 'category' to 'geogrpahical coverage'
- Set 'day' as default accuracy
- Set 'unknown' as default displacement
- Enable review on entry view page
- Remove two different comment box on review page
- Fix prop values for traffic light inputs
- Hide action buttons on traffic light input if disabled
- Hide page change control on Entries table
- Use network-and-cache for apollo client

Addresses https://github.com/idmc-labs/Helix2.0/pull/263
Addresses https://github.com/idmc-labs/Helix2.0/pull/262
Addresses https://github.com/idmc-labs/Helix2.0/pull/252
Addresses https://github.com/idmc-labs/Helix2.0/pull/251
Addresses https://github.com/idmc-labs/Helix2.0/pull/277

Depends on https://github.com/idmc-labs/helix-server/pull/238
Depends on https://github.com/idmc-labs/helix-migration/pull/49

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
