### PR TITLE
Add changes to assigning reviewers logic

### DIFF
--- a/src/views/Entry/EntryForm/ReviewInput/index.tsx
+++ b/src/views/Entry/EntryForm/ReviewInput/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
     gql,
     useMutation,
@@ -189,6 +189,12 @@ function Review<N extends string>(props: ReviewInputProps<N>) {
         }
     }, [updateEntryReview, entryId]);
 
+    const handleReviewerChange = useCallback(() => {
+        console.log('Handle review:::>>');
+    }, []);
+
+    const reviewerSaveDisabled = value && value.length === 0;
+
     return (
         <>
             <Row>
@@ -210,6 +216,15 @@ function Review<N extends string>(props: ReviewInputProps<N>) {
                             comment={review.reviewers?.comment}
                             onChange={onReviewChange}
                         />
+                    )}
+                    actions={(
+                        <Button
+                            name={undefined}
+                            onClick={handleReviewerChange}
+                            disabled={reviewerSaveDisabled}
+                        >
+                            Save
+                        </Button>
                     )}
                 />
             </Row>

--- a/src/views/Entry/EntryForm/ReviewInput/index.tsx
+++ b/src/views/Entry/EntryForm/ReviewInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import {
     gql,
     useMutation,

--- a/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
+++ b/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
@@ -150,6 +150,7 @@ function ReviewSaveInput<N extends string>(props: ReviewInputProps<N>) {
 
     const [
         updateEntryReviewer,
+        { loading: updateEntryReviewerLoading },
     ] = useMutation<UpdateEntryReviewerMutation, UpdateEntryReviewerMutationVariables>(
         UPDATE_ENTRY_REVIEWER,
         {
@@ -258,6 +259,7 @@ function ReviewSaveInput<N extends string>(props: ReviewInputProps<N>) {
                     actions={entryPermissions?.change && !reviewerSaveDisabled && (
                         <Button
                             name={undefined}
+                            disabled={updateEntryReviewerLoading}
                             onClick={handleReviewerChange}
                         >
                             Save

--- a/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
+++ b/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
@@ -242,8 +242,6 @@ function ReviewSaveInput<N extends string>(props: ReviewInputProps<N>) {
         }
     }, [updateEntryReviewer, entryId, value]);
 
-    const reviewerSaveDisabled = value && value.length === 0;
-
     return (
         <>
             <Row>
@@ -256,13 +254,14 @@ function ReviewSaveInput<N extends string>(props: ReviewInputProps<N>) {
                     options={users}
                     onOptionsChange={setUsers}
                     error={error?.$internal}
-                    actions={entryPermissions?.change && !reviewerSaveDisabled && (
+                    actions={entryPermissions?.change && (
                         <Button
                             name={undefined}
-                            disabled={updateEntryReviewerLoading}
+                            disabled={disabled || updateEntryReviewerLoading}
                             onClick={handleReviewerChange}
+                            transparent
                         >
-                            Save
+                            Save reviewers
                         </Button>
                     )}
                     readOnly={!entryPermissions?.change}

--- a/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
+++ b/src/views/Entry/EntryForm/ReviewSaveInput/index.tsx
@@ -255,68 +255,62 @@ function ReviewSaveInput<N extends string>(props: ReviewInputProps<N>) {
                     options={users}
                     onOptionsChange={setUsers}
                     error={error?.$internal}
-                    actions={(
+                    actions={entryPermissions?.change && !reviewerSaveDisabled && (
                         <Button
                             name={undefined}
                             onClick={handleReviewerChange}
-                            disabled={reviewerSaveDisabled}
                         >
                             Save
                         </Button>
                     )}
+                    readOnly={!entryPermissions?.change}
                 />
             </Row>
-            {reviewMode && (
-                <>
-                    {hasBeenSignedOff ? (
-                        <>
-                            {entryPermissions?.sign_off && reviewer?.status === 'SIGNED_OFF' && (
-                                <Row singleColumnNoGrow>
+            <Row singleColumnNoGrow>
+                {reviewMode && (
+                    <>
+                        {hasBeenSignedOff ? (
+                            <>
+                                {entryPermissions?.sign_off && reviewer?.status === 'SIGNED_OFF' && (
                                     <Button
                                         name={undefined}
                                         onClick={handleUndoReviewClick}
                                     >
                                         Mark as under review
                                     </Button>
-                                </Row>
-                            )}
-                        </>
-                    ) : (
-                        <>
-                            {reviewPermissions?.add && (!reviewer || reviewer.status !== 'UNDER_REVIEW') && (
-                                <Row singleColumnNoGrow>
+                                )}
+                            </>
+                        ) : (
+                            <>
+                                {reviewPermissions?.add && (!reviewer || reviewer.status !== 'UNDER_REVIEW') && (
                                     <Button
                                         name={undefined}
                                         onClick={handleUndoReviewClick}
                                     >
                                         Mark as under review
                                     </Button>
-                                </Row>
-                            )}
-                            {reviewPermissions?.add && (!reviewer || reviewer.status !== 'REVIEW_COMPLETED') && (
-                                <Row singleColumnNoGrow>
+                                )}
+                                {reviewPermissions?.add && (!reviewer || reviewer.status !== 'REVIEW_COMPLETED') && (
                                     <Button
                                         name={undefined}
                                         onClick={handleCompleteReviewClick}
                                     >
                                         Approve
                                     </Button>
-                                </Row>
-                            )}
-                            {entryPermissions?.sign_off && (
-                                <Row singleColumnNoGrow>
+                                )}
+                                {entryPermissions?.sign_off && (
                                     <Button
                                         name={undefined}
                                         onClick={handleSignOffClick}
                                     >
                                         Sign off
                                     </Button>
-                                </Row>
-                            )}
-                        </>
-                    )}
-                </>
-            )}
+                                )}
+                            </>
+                        )}
+                    </>
+                )}
+            </Row>
             <div className={styles.reviewStatuses}>
                 {reviewing?.map((item) => (
                     <div

--- a/src/views/Entry/EntryForm/ReviewSaveInput/styles.css
+++ b/src/views/Entry/EntryForm/ReviewSaveInput/styles.css
@@ -1,0 +1,9 @@
+.review-statuses {
+    display: flex;
+    flex-direction: column;
+    padding: var(--spacing-medium);
+
+    .review-status {
+        padding: var(--spacing-small) 0;
+    }
+}

--- a/src/views/Entry/EntryForm/index.tsx
+++ b/src/views/Entry/EntryForm/index.tsx
@@ -1134,7 +1134,6 @@ function EntryForm(props: EntryFormProps) {
                                 value={value.reviewers}
                                 disabled={loading || !processed}
                                 mode={mode}
-                                entryId={entryId}
                                 reviewing={entryData?.entry?.reviewing}
                                 users={users}
                                 setUsers={setUsers}

--- a/src/views/Entry/EntryForm/index.tsx
+++ b/src/views/Entry/EntryForm/index.tsx
@@ -99,6 +99,7 @@ import {
 } from './types';
 
 import styles from './styles.css';
+import ReviewSaveInput from './ReviewSaveInput';
 
 type EntryFormFields = CreateEntryMutationVariables['entry'];
 type PartialFormValues = PartialForm<FormValues>;
@@ -897,14 +898,12 @@ function EntryForm(props: EntryFormProps) {
                         >
                             Figure and Analysis
                         </Tab>
-                        {editMode && (
-                            <Tab
-                                name="review"
-                                className={_cs(reviewErrored && styles.errored)}
-                            >
-                                Review
-                            </Tab>
-                        )}
+                        <Tab
+                            name="review"
+                            className={_cs(reviewErrored && styles.errored)}
+                        >
+                            Review
+                        </Tab>
                     </TabList>
                     <NonFieldError className={styles.generalError}>
                         {error?.$internal}
@@ -1110,11 +1109,24 @@ function EntryForm(props: EntryFormProps) {
                             ))}
                         </Section>
                     </TabPanel>
-                    {editMode && (
-                        <TabPanel
-                            className={styles.review}
-                            name="review"
-                        >
+                    <TabPanel
+                        className={styles.review}
+                        name="review"
+                    >
+                        {reviewMode ? (
+                            <ReviewSaveInput
+                                error={error?.fields?.reviewers}
+                                name="reviewers"
+                                onChange={onValueChange}
+                                value={value.reviewers}
+                                disabled={loading || !processed}
+                                mode={mode}
+                                entryId={entryId}
+                                reviewing={entryData?.entry?.reviewing}
+                                users={users}
+                                setUsers={setUsers}
+                            />
+                        ) : (
                             <ReviewInput
                                 error={error?.fields?.reviewers}
                                 name="reviewers"
@@ -1130,8 +1142,8 @@ function EntryForm(props: EntryFormProps) {
                                 review={review}
                                 onReviewChange={handleReviewChange}
                             />
-                        </TabPanel>
-                    )}
+                        )}
+                    </TabPanel>
                 </Tabs>
             </form>
         </>

--- a/src/views/Entry/EntryForm/index.tsx
+++ b/src/views/Entry/EntryForm/index.tsx
@@ -897,12 +897,14 @@ function EntryForm(props: EntryFormProps) {
                         >
                             Figure and Analysis
                         </Tab>
-                        <Tab
-                            name="review"
-                            className={_cs(reviewErrored && styles.errored)}
-                        >
-                            Review
-                        </Tab>
+                        {editMode && (
+                            <Tab
+                                name="review"
+                                className={_cs(reviewErrored && styles.errored)}
+                            >
+                                Review
+                            </Tab>
+                        )}
                     </TabList>
                     <NonFieldError className={styles.generalError}>
                         {error?.$internal}
@@ -1108,26 +1110,28 @@ function EntryForm(props: EntryFormProps) {
                             ))}
                         </Section>
                     </TabPanel>
-                    <TabPanel
-                        className={styles.review}
-                        name="review"
-                    >
-                        <ReviewInput
-                            error={error?.fields?.reviewers}
-                            name="reviewers"
-                            onChange={onValueChange}
-                            value={value.reviewers}
-                            disabled={loading || !processed}
-                            mode={mode}
-                            entryId={entryId}
-                            reviewing={entryData?.entry?.reviewing}
-                            users={users}
-                            setUsers={setUsers}
-                            trafficLightShown={trafficLightShown}
-                            review={review}
-                            onReviewChange={handleReviewChange}
-                        />
-                    </TabPanel>
+                    {editMode && (
+                        <TabPanel
+                            className={styles.review}
+                            name="review"
+                        >
+                            <ReviewInput
+                                error={error?.fields?.reviewers}
+                                name="reviewers"
+                                onChange={onValueChange}
+                                value={value.reviewers}
+                                disabled={loading || !processed}
+                                mode={mode}
+                                entryId={entryId}
+                                reviewing={entryData?.entry?.reviewing}
+                                users={users}
+                                setUsers={setUsers}
+                                trafficLightShown={trafficLightShown}
+                                review={review}
+                                onReviewChange={handleReviewChange}
+                            />
+                        </TabPanel>
+                    )}
                 </Tabs>
             </form>
         </>

--- a/src/views/Entry/EntryForm/queries.tsx
+++ b/src/views/Entry/EntryForm/queries.tsx
@@ -241,6 +241,15 @@ export const UPDATE_ENTRY = gql`
                         totalStockIdpFigures
                       }
                 }
+                reviewing {
+                    id
+                    status
+                    createdAt
+                    reviewer {
+                        id
+                        fullName
+                    }
+                }
                 totalFlowNdFigures
                 totalStockIdpFigures
             }


### PR DESCRIPTION
## Addresses:
- https://freedcamp.com/view/2779007/tasks/panel/task/42836172
- https://github.com/idmc-labs/Helix2.0/issues/259
- https://github.com/idmc-labs/Helix2.0/issues/265

## Changes:
- Allow users to assign reviewers only in editMode
- Integrate a separate query for adding reviewers

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
