### PR TITLE
Add is-admin column in users table

### DIFF
--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -44,7 +44,6 @@ const ME = gql`
     query Me {
       me {
           id
-          highestRole
           fullName
           permissions {
               action

--- a/src/views/Admin/UserRoles/UserActions/index.tsx
+++ b/src/views/Admin/UserRoles/UserActions/index.tsx
@@ -17,11 +17,11 @@ type UserRolesField = NonNullable<NonNullable<UserListQuery['users']>['results']
 export interface ActionProps {
     id: string;
     className?: string;
-    roleStatus?: string | null | undefined;
+    isAdmin?: boolean | null | undefined;
     activeStatus?: boolean;
     user?: UserRolesField | undefined;
     onToggleUserActiveStatus?: (id: string, activeStatus: boolean) => void;
-    onToggleRoleStatus?: (id: string, roleStatus: boolean) => void;
+    onToggleRoleStatus?: (id: string, isAdmin: boolean) => void;
     disabled?: boolean;
     children?: React.ReactNode;
 }
@@ -35,7 +35,7 @@ function ActionCell(props: ActionProps) {
         disabled,
         children,
         activeStatus,
-        roleStatus,
+        isAdmin,
     } = props;
 
     const handleToggleUserActiveStatus = React.useCallback(
@@ -50,10 +50,10 @@ function ActionCell(props: ActionProps) {
     const handleToggleRoleStatus = useCallback(
         () => {
             if (onToggleRoleStatus) {
-                onToggleRoleStatus(id, roleStatus === 'ADMIN');
+                onToggleRoleStatus(id, !!isAdmin);
             }
         },
-        [onToggleRoleStatus, id, roleStatus],
+        [onToggleRoleStatus, id, isAdmin],
     );
 
     return (
@@ -63,11 +63,11 @@ function ActionCell(props: ActionProps) {
                 <QuickActionConfirmButton
                     name={undefined}
                     onConfirm={handleToggleRoleStatus}
-                    title={roleStatus !== 'ADMIN' ? 'Grant admin access' : 'Revoke admin access'}
+                    title={!isAdmin ? 'Grant admin access' : 'Revoke admin access'}
                     disabled={disabled || !onToggleRoleStatus}
                     confirmationMessage="Are you sure you want to change the user admin access?"
                 >
-                    {roleStatus !== 'ADMIN' ? <IoPersonAdd /> : <IoPersonRemove />}
+                    {!isAdmin ? <IoPersonAdd /> : <IoPersonRemove />}
                 </QuickActionConfirmButton>
             )}
             {onToggleUserActiveStatus && (

--- a/src/views/Admin/UserRoles/UserFilter/index.tsx
+++ b/src/views/Admin/UserRoles/UserFilter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { TextInput, Button, MultiSelectInput } from '@togglecorp/toggle-ui';
 import { _cs } from '@togglecorp/fujs';
 import { gql, useQuery } from '@apollo/client';
@@ -109,12 +109,20 @@ function UserFilter(props: UsersFilterProps) {
         [onValueSet, onFilterChange],
     );
 
-    const handleSubmit = React.useCallback((finalValues: FormType) => {
+    const handleSubmit = useCallback((finalValues: FormType) => {
         onValueSet(finalValues);
         onFilterChange(finalValues);
     }, [onValueSet, onFilterChange]);
 
     const filterChanged = defaultFormValues !== value;
+
+    const roleOptionsForPortfolio = useMemo(
+        () => rolesOptions
+            ?.roleList
+            ?.enumValues
+            ?.filter((item) => (item.name !== 'ADMIN' && item.name !== 'GUEST')),
+        [rolesOptions],
+    );
 
     return (
         <form
@@ -138,7 +146,7 @@ function UserFilter(props: UsersFilterProps) {
                     className={styles.input}
                     label="Roles"
                     name="roleIn"
-                    options={rolesOptions?.roleList?.enumValues}
+                    options={roleOptionsForPortfolio}
                     value={value.roleIn}
                     keySelector={enumKeySelector}
                     labelSelector={enumLabelSelector}

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -88,6 +88,7 @@ const TOGGLE_USER_ROLE_STATUS = gql`
             result {
                 highestRole
                 id
+                isAdmin
             }
         }
     }

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -56,6 +56,7 @@ query UserList(
         results {
             dateJoined
             isActive
+            isAdmin
             id
             fullName
             highestRole
@@ -289,6 +290,12 @@ function UserRoles(props: UserRolesProps) {
                     // { sortable: true },
                     undefined,
                     'large',
+                ),
+                createYesNoColumn<UserRolesField, string>(
+                    'is_admin',
+                    'Admin',
+                    (item) => item.isAdmin,
+                    { sortable: true },
                 ),
                 createYesNoColumn<UserRolesField, string>(
                     'is_active',

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -59,7 +59,7 @@ query UserList(
             isAdmin
             id
             fullName
-            highestRole
+            portfolioRole
         }
         totalCount
         pageSize
@@ -86,7 +86,7 @@ const TOGGLE_USER_ROLE_STATUS = gql`
             errors
             ok
             result {
-                highestRole
+                portfolioRole
                 id
                 isAdmin
             }
@@ -264,7 +264,7 @@ function UserRoles(props: UserRolesProps) {
                 cellRendererParams: (_, datum) => ({
                     id: datum.id,
                     activeStatus: datum.isActive,
-                    roleStatus: datum.highestRole,
+                    isAdmin: datum.isAdmin,
                     onToggleUserActiveStatus: handleToggleUserActiveStatus,
                     onToggleRoleStatus: handleToggleRoleStatus,
                 }),
@@ -285,9 +285,9 @@ function UserRoles(props: UserRolesProps) {
                     'large',
                 ),
                 createTextColumn<UserRolesField, string>(
-                    'highest_role',
+                    'portfolio_role',
                     'Role',
-                    (item) => item.highestRole,
+                    (item) => item.portfolioRole,
                     // { sortable: true },
                     undefined,
                     'large',
@@ -296,7 +296,7 @@ function UserRoles(props: UserRolesProps) {
                     'is_admin',
                     'Admin',
                     (item) => item.isAdmin,
-                    { sortable: true },
+                    // { sortable: true },
                 ),
                 createYesNoColumn<UserRolesField, string>(
                     'is_active',

--- a/src/views/SignIn/index.tsx
+++ b/src/views/SignIn/index.tsx
@@ -42,7 +42,6 @@ const LOGIN = gql`
       result {
         email
         id
-        highestRole
         fullName
         permissions {
             action
@@ -130,7 +129,6 @@ function SignIn() {
                     onErrorSet(formError);
                 } else if (ok) {
                     // NOTE: there can be case where errors is empty but it still errored
-                    // FIXME: highestRole is sent as string from the server
                     setUser(removeNull(result));
                     const urlParams = new URLSearchParams(window.location.search);
                     const redirect = urlParams.get('redirect-to-mmp');


### PR DESCRIPTION
## Addresses:
- https://github.com/idmc-labs/helix2.0-meta/issues/67#issue-1262987116

## Depends:
- https://github.com/idmc-labs/helix-server/pull/274#issue-1263233362

## Changes:
- Added isAdmin column in users table
- Updated the users query in order to re-fetch after isAdmin is updated

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
