### PR TITLE
Add route logic to edit button in figure tables

### DIFF
--- a/src/components/ButtonLikeLink/index.tsx
+++ b/src/components/ButtonLikeLink/index.tsx
@@ -16,6 +16,8 @@ export interface ButtonLikeLinkProps extends PropsFromButton {
     route: RouteData,
     attrs?: Attrs,
     title?: string;
+    hash?: string;
+    search?: string;
 }
 
 function ButtonLikeLink(props: ButtonLikeLinkProps) {
@@ -23,6 +25,8 @@ function ButtonLikeLink(props: ButtonLikeLinkProps) {
         route,
         attrs,
         title,
+        hash,
+        search,
         ...buttonProps
     } = props;
 
@@ -37,9 +41,11 @@ function ButtonLikeLink(props: ButtonLikeLinkProps) {
             route={route}
             attrs={attrs}
             title={title}
+            hash={hash}
+            search={search}
         >
             <VisualFeedback />
-            { children }
+            {children}
         </SmartLink>
     );
 }

--- a/src/components/tableHelpers/Action.tsx
+++ b/src/components/tableHelpers/Action.tsx
@@ -20,6 +20,8 @@ export interface ActionProps {
     children?: React.ReactNode;
     editLinkRoute?: RouteData;
     editLinkAttrs?: Attrs;
+    editHash?: string;
+    editSearch?: string;
 }
 
 function ActionCell(props: ActionProps) {
@@ -32,6 +34,8 @@ function ActionCell(props: ActionProps) {
         children,
         editLinkRoute,
         editLinkAttrs,
+        editHash,
+        editSearch,
     } = props;
 
     const handleDeleteButtonClick = useCallback(
@@ -59,6 +63,8 @@ function ActionCell(props: ActionProps) {
                     route={editLinkRoute}
                     attrs={editLinkAttrs}
                     title="Edit"
+                    hash={editHash}
+                    search={editSearch}
                 >
                     <IoMdCreate />
                 </QuickActionLink>

--- a/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
@@ -292,12 +292,14 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'Figure Category',
                     (item) => ({
                         title: item.category,
-                        attrs: { eventId: item.event?.id },
+                        attrs: { entryId: item.entry.id },
                         ext: item.oldId
                             ? `/facts/${item.oldId}`
                             : undefined,
+                        hash: '/figures-and-analysis',
+                        search: `id=${item.id}`,
                     }),
-                    route.event,
+                    route.entryView,
                     { sortable: true },
                 ),
                 createNumberColumn<FigureFields, string>(

--- a/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
@@ -220,6 +220,8 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     onDelete: entryPermissions?.delete ? handleFigureDelete : undefined,
                     editLinkRoute: route.entryEdit,
                     editLinkAttrs: { entryId: datum.entry.id },
+                    editHash: '/figures-and-analysis',
+                    editSearch: `id=${datum.id}`,
                 }),
             };
 

--- a/src/views/Dashboard/EntriesForReview/index.tsx
+++ b/src/views/Dashboard/EntriesForReview/index.tsx
@@ -138,7 +138,7 @@ function EntriesForReview(props: EntriesForReviewProps) {
                 },
                 cellRenderer: ActionCell,
                 cellRendererParams: (_, datum) => ({
-                    viewLinkRoute: route.entryView,
+                    viewLinkRoute: route.entryEdit,
                     viewLinkAttrs: { entryId: datum.entry.id },
                 }),
             };

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -238,6 +238,8 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     onDelete: entryPermissions?.delete ? handleFigureDelete : undefined,
                     editLinkRoute: route.entryEdit,
                     editLinkAttrs: { entryId: datum.entry.id },
+                    editHash: '/figures-and-analysis',
+                    editSearch: `id=${datum.id}`,
                 }),
             };
 

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -270,12 +270,14 @@ function ReportFigureTable(props: ReportFigureProps) {
                 'Figure Category',
                 (item) => ({
                     title: item.category,
-                    attrs: { eventId: item.event.id },
+                    attrs: { entryId: item.entry.id },
                     ext: item.oldId
                         ? `/facts/${item.oldId}`
                         : undefined,
+                    hash: '/figures-and-analysis',
+                    search: `id=${item.id}`,
                 }),
-                route.event,
+                route.entryView,
                 { sortable: true },
             ),
             createNumberColumn<ReportFigureFields, string>(


### PR DESCRIPTION
## Changes:
- Enable new route logic to edit buttons for entries table to redirect to respective figure ID
- **Also add missing route logic to figure category columns to respective figure tables throughout the helix project**

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
