### PR TITLE
Fix the order of crisis column in multiple tables

### DIFF
--- a/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
@@ -236,19 +236,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     (item) => item.createdBy?.fullName,
                     { sortable: true },
                 ),
-                crisisColumnHidden
-                    ? undefined
-                    : createLinkColumn<FigureFields, string>(
-                        'event__crisis__name',
-                        'Crisis',
-                        (item) => ({
-                            title: item.event?.crisis?.name,
-                            attrs: { crisisId: item.event?.crisis?.id },
-                            ext: undefined,
-                        }),
-                        route.crisis,
-                        { sortable: true },
-                    ),
                 eventColumnHidden
                     ? undefined
                     : createLinkColumn<FigureFields, string>(
@@ -345,6 +332,19 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     (item) => item.endDate,
                     { sortable: true },
                 ),
+                crisisColumnHidden
+                    ? undefined
+                    : createLinkColumn<FigureFields, string>(
+                        'event__crisis__name',
+                        'Crisis',
+                        (item) => ({
+                            title: item.event?.crisis?.name,
+                            attrs: { crisisId: item.event?.crisis?.id },
+                            ext: undefined,
+                        }),
+                        route.crisis,
+                        { sortable: true },
+                    ),
                 actionColumn,
             ].filter(isDefined);
         },

--- a/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesTable/NudeFigureTable/index.tsx
@@ -236,22 +236,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     (item) => item.createdBy?.fullName,
                     { sortable: true },
                 ),
-                eventColumnHidden
-                    ? undefined
-                    : createLinkColumn<FigureFields, string>(
-                        'event__name',
-                        'Event',
-                        (item) => ({
-                            title: item.event?.name,
-                            // FIXME: this may be wrong
-                            attrs: { eventId: item.event?.id },
-                            ext: item.event?.oldId
-                                ? `/events/${item.event.oldId}`
-                                : undefined,
-                        }),
-                        route.event,
-                        { sortable: true },
-                    ),
                 entryColumnHidden
                     ? undefined
                     : createStatusColumn<FigureFields, string>(
@@ -332,6 +316,22 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     (item) => item.endDate,
                     { sortable: true },
                 ),
+                eventColumnHidden
+                    ? undefined
+                    : createLinkColumn<FigureFields, string>(
+                        'event__name',
+                        'Event',
+                        (item) => ({
+                            title: item.event?.name,
+                            // FIXME: this may be wrong
+                            attrs: { eventId: item.event?.id },
+                            ext: item.event?.oldId
+                                ? `/events/${item.event.oldId}`
+                                : undefined,
+                        }),
+                        route.event,
+                        { sortable: true },
+                    ),
                 crisisColumnHidden
                     ? undefined
                     : createLinkColumn<FigureFields, string>(

--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -522,19 +522,6 @@ function EventsTable(props: EventsProps) {
                     (item) => item.createdBy?.fullName,
                     { sortable: true },
                 ),
-                crisisId
-                    ? undefined
-                    : createLinkColumn<EventFields, string>(
-                        'crisis__name',
-                        'Crisis',
-                        (item) => ({
-                            title: item.crisis?.name,
-                            attrs: { crisisId: item.crisis?.id },
-                            ext: undefined,
-                        }),
-                        route.crisis,
-                        { sortable: true },
-                    ),
                 createLinkColumn<EventFields, string>(
                     'name',
                     'Name',
@@ -601,6 +588,19 @@ function EventsTable(props: EventsProps) {
                     { sortable: true },
                 ),
                 progressColumn,
+                crisisId
+                    ? undefined
+                    : createLinkColumn<EventFields, string>(
+                        'crisis__name',
+                        'Crisis',
+                        (item) => ({
+                            title: item.crisis?.name,
+                            attrs: { crisisId: item.crisis?.id },
+                            ext: undefined,
+                        }),
+                        route.crisis,
+                        { sortable: true },
+                    ),
                 qaMode === undefined ? actionColumn : null,
                 qaMode === 'IGNORE_QA' ? unIgnoreActionColumn : null,
                 qaMode === 'NO_RF' ? ignoreActionColumn : null,

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -254,20 +254,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     (item) => item.createdBy?.fullName,
                     { sortable: true },
                 ),
-                createLinkColumn<FigureFields, string>(
-                    'event__name',
-                    'Event',
-                    (item) => ({
-                        title: item.event?.name,
-                        // FIXME: this may be wrong
-                        attrs: { eventId: item.event?.id },
-                        ext: item.event?.oldId
-                            ? `/events/${item.event.oldId}`
-                            : undefined,
-                    }),
-                    route.event,
-                    { sortable: true },
-                ),
                 createStatusColumn<FigureFields, string>(
                     'entry__article_title',
                     'Entry',
@@ -346,6 +332,20 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'end_date',
                     'End Date',
                     (item) => item.endDate,
+                    { sortable: true },
+                ),
+                createLinkColumn<FigureFields, string>(
+                    'event__name',
+                    'Event',
+                    (item) => ({
+                        title: item.event?.name,
+                        // FIXME: this may be wrong
+                        attrs: { eventId: item.event?.id },
+                        ext: item.event?.oldId
+                            ? `/events/${item.event.oldId}`
+                            : undefined,
+                    }),
+                    route.event,
                     { sortable: true },
                 ),
                 createLinkColumn<FigureFields, string>(

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -255,17 +255,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createLinkColumn<FigureFields, string>(
-                    'event__crisis__name',
-                    'Crisis',
-                    (item) => ({
-                        title: item.event?.crisis?.name,
-                        attrs: { crisisId: item.event?.crisis?.id },
-                        ext: undefined,
-                    }),
-                    route.crisis,
-                    { sortable: true },
-                ),
-                createLinkColumn<FigureFields, string>(
                     'event__name',
                     'Event',
                     (item) => ({
@@ -357,6 +346,17 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'end_date',
                     'End Date',
                     (item) => item.endDate,
+                    { sortable: true },
+                ),
+                createLinkColumn<FigureFields, string>(
+                    'event__crisis__name',
+                    'Crisis',
+                    (item) => ({
+                        title: item.event?.crisis?.name,
+                        attrs: { crisisId: item.event?.crisis?.id },
+                        ext: undefined,
+                    }),
+                    route.crisis,
                     { sortable: true },
                 ),
                 actionColumn,

--- a/src/views/Report/ReportEventTable/index.tsx
+++ b/src/views/Report/ReportEventTable/index.tsx
@@ -210,17 +210,6 @@ function ReportEventTable(props: ReportEventProps) {
             };
             return [
                 createLinkColumn<ReportEventFields, string>(
-                    'crisis__name',
-                    'Crisis',
-                    (item) => ({
-                        title: item.crisis?.name,
-                        attrs: { eventId: item.crisis?.id },
-                        ext: undefined,
-                    }),
-                    route.crisis,
-                    { sortable: true },
-                ),
-                createLinkColumn<ReportEventFields, string>(
                     'name',
                     'Name',
                     (item) => ({
@@ -271,6 +260,17 @@ function ReportEventTable(props: ReportEventProps) {
                     'total_stock_idp_figures',
                     'No. of IDPs',
                     (item) => item.totalStockIdpFigures,
+                    { sortable: true },
+                ),
+                createLinkColumn<ReportEventFields, string>(
+                    'crisis__name',
+                    'Crisis',
+                    (item) => ({
+                        title: item.crisis?.name,
+                        attrs: { eventId: item.crisis?.id },
+                        ext: undefined,
+                    }),
+                    route.crisis,
                     { sortable: true },
                 ),
                 progressColumn,

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -220,17 +220,6 @@ function ReportFigureTable(props: ReportFigureProps) {
                 { sortable: true },
             ),
             createLinkColumn<ReportFigureFields, string>(
-                'event__crisis__name',
-                'Crisis',
-                (item) => ({
-                    title: item.event?.crisis?.name,
-                    attrs: { crisisId: item.event?.crisis?.id },
-                    ext: undefined,
-                }),
-                route.crisis,
-                { sortable: true },
-            ),
-            createLinkColumn<ReportFigureFields, string>(
                 'event__name',
                 'Event',
                 (item) => ({
@@ -318,6 +307,17 @@ function ReportFigureTable(props: ReportFigureProps) {
                 'end_date',
                 'End Date',
                 (item) => item.endDate,
+                { sortable: true },
+            ),
+            createLinkColumn<ReportFigureFields, string>(
+                'event__crisis__name',
+                'Crisis',
+                (item) => ({
+                    title: item.event?.crisis?.name,
+                    attrs: { crisisId: item.event?.crisis?.id },
+                    ext: undefined,
+                }),
+                route.crisis,
                 { sortable: true },
             ),
         ]),

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -219,19 +219,6 @@ function ReportFigureTable(props: ReportFigureProps) {
                 (item) => item.createdBy?.fullName,
                 { sortable: true },
             ),
-            createLinkColumn<ReportFigureFields, string>(
-                'event__name',
-                'Event',
-                (item) => ({
-                    title: item.event?.name,
-                    attrs: { eventId: item.event?.id },
-                    ext: item.event?.oldId
-                        ? `/events/${item.event.oldId}`
-                        : undefined,
-                }),
-                route.event,
-                { sortable: true },
-            ),
             createTextColumn<ReportFigureFields, string>(
                 'entry__event__event_type',
                 'Cause',
@@ -307,6 +294,19 @@ function ReportFigureTable(props: ReportFigureProps) {
                 'end_date',
                 'End Date',
                 (item) => item.endDate,
+                { sortable: true },
+            ),
+            createLinkColumn<ReportFigureFields, string>(
+                'event__name',
+                'Event',
+                (item) => ({
+                    title: item.event?.name,
+                    attrs: { eventId: item.event?.id },
+                    ext: item.event?.oldId
+                        ? `/events/${item.event.oldId}`
+                        : undefined,
+                }),
+                route.event,
                 { sortable: true },
             ),
             createLinkColumn<ReportFigureFields, string>(


### PR DESCRIPTION
## Addresses:
- issue: https://github.com/idmc-labs/helix2.0-meta/issues/71#issue-1263012357

## Changes:
- Re-arrange the ordering of crisis columns throughout helix project 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
