### PR TITLE
Fix re-fetch query logic of resources component

### DIFF
--- a/src/components/forms/ContactForm/index.tsx
+++ b/src/components/forms/ContactForm/index.tsx
@@ -402,6 +402,25 @@ function ContactForm(props: ContactFormProps) {
                 {error?.$internal}
             </NonFieldError>
             <Row>
+                <TextInput
+                    label="First Name *"
+                    value={value.firstName}
+                    onChange={onValueChange}
+                    name="firstName"
+                    error={error?.fields?.firstName}
+                    disabled={disabled}
+                    autoFocus
+                />
+                <TextInput
+                    label="Last Name *"
+                    onChange={onValueChange}
+                    value={value.lastName}
+                    name="lastName"
+                    error={error?.fields?.lastName}
+                    disabled={disabled}
+                />
+            </Row>
+            <Row>
                 <SelectInput
                     label="Designation *"
                     name="designation"
@@ -412,7 +431,6 @@ function ContactForm(props: ContactFormProps) {
                     onChange={onValueChange}
                     error={error?.fields?.designation}
                     disabled={disabled || contactOptionsLoading || !!contactOptionsError}
-                    autoFocus
                 />
                 <SelectInput
                     label="Gender *"
@@ -424,24 +442,6 @@ function ContactForm(props: ContactFormProps) {
                     onChange={onValueChange}
                     error={error?.fields?.gender}
                     disabled={disabled || contactOptionsLoading || !!contactOptionsError}
-                />
-            </Row>
-            <Row>
-                <TextInput
-                    label="First Name *"
-                    value={value.firstName}
-                    onChange={onValueChange}
-                    name="firstName"
-                    error={error?.fields?.firstName}
-                    disabled={disabled}
-                />
-                <TextInput
-                    label="Last Name *"
-                    onChange={onValueChange}
-                    value={value.lastName}
-                    name="lastName"
-                    error={error?.fields?.lastName}
-                    disabled={disabled}
                 />
             </Row>
             <Row>

--- a/src/components/lists/MyResources/GroupForm/index.tsx
+++ b/src/components/lists/MyResources/GroupForm/index.tsx
@@ -60,7 +60,6 @@ const schema: FormSchema = {
 
 const defaultFormValues: PartialForm<FormType> = {};
 interface GroupFormProps {
-    onGroupFormClose: () => void;
     onAddNewGroupInCache: MutationUpdaterFn<CreateResourceGroupMutation>;
     handleNewGroupName: (groupName: string | undefined) => void;
 }
@@ -68,7 +67,6 @@ interface GroupFormProps {
 // TODO: handle group edit
 function GroupForm(props: GroupFormProps) {
     const {
-        onGroupFormClose,
         onAddNewGroupInCache,
         handleNewGroupName,
     } = props;
@@ -113,7 +111,6 @@ function GroupForm(props: GroupFormProps) {
                     });
                     onPristineSet(true);
                     handleNewGroupName(createResourceGroupRes?.result?.id);
-                    onGroupFormClose();
                 }
             },
             onError: (errors) => {
@@ -157,7 +154,7 @@ function GroupForm(props: GroupFormProps) {
             <FormActions className={styles.actions}>
                 <Button
                     name={undefined}
-                    onClick={onGroupFormClose}
+                    onClick={handleNewGroupName}
                     disabled={createGroupLoading}
                 >
                     Cancel

--- a/src/components/lists/MyResources/GroupForm/index.tsx
+++ b/src/components/lists/MyResources/GroupForm/index.tsx
@@ -61,14 +61,13 @@ const schema: FormSchema = {
 const defaultFormValues: PartialForm<FormType> = {};
 interface GroupFormProps {
     onAddNewGroupInCache: MutationUpdaterFn<CreateResourceGroupMutation>;
-    handleNewGroupName: (groupName: string | undefined) => void;
+    onAddNewGroup: (groupName: string | undefined) => void;
 }
 
-// TODO: handle group edit
 function GroupForm(props: GroupFormProps) {
     const {
         onAddNewGroupInCache,
-        handleNewGroupName,
+        onAddNewGroup,
     } = props;
 
     const {
@@ -110,7 +109,7 @@ function GroupForm(props: GroupFormProps) {
                         variant: 'success',
                     });
                     onPristineSet(true);
-                    handleNewGroupName(createResourceGroupRes?.result?.id);
+                    onAddNewGroup(createResourceGroupRes?.result?.id);
                 }
             },
             onError: (errors) => {
@@ -154,7 +153,7 @@ function GroupForm(props: GroupFormProps) {
             <FormActions className={styles.actions}>
                 <Button
                     name={undefined}
-                    onClick={handleNewGroupName}
+                    onClick={onAddNewGroup}
                     disabled={createGroupLoading}
                 >
                     Cancel

--- a/src/components/lists/MyResources/GroupForm/index.tsx
+++ b/src/components/lists/MyResources/GroupForm/index.tsx
@@ -59,10 +59,10 @@ const schema: FormSchema = {
 };
 
 const defaultFormValues: PartialForm<FormType> = {};
-
 interface GroupFormProps {
     onGroupFormClose: () => void;
     onAddNewGroupInCache: MutationUpdaterFn<CreateResourceGroupMutation>;
+    handleNewGroupName: (groupName: string | undefined) => void;
 }
 
 // TODO: handle group edit
@@ -70,6 +70,7 @@ function GroupForm(props: GroupFormProps) {
     const {
         onGroupFormClose,
         onAddNewGroupInCache,
+        handleNewGroupName,
     } = props;
 
     const {
@@ -111,6 +112,7 @@ function GroupForm(props: GroupFormProps) {
                         variant: 'success',
                     });
                     onPristineSet(true);
+                    handleNewGroupName(createResourceGroupRes?.result?.id);
                     onGroupFormClose();
                 }
             },

--- a/src/components/lists/MyResources/ResourceForm/index.tsx
+++ b/src/components/lists/MyResources/ResourceForm/index.tsx
@@ -3,7 +3,9 @@ import {
     TextInput,
     SelectInput,
     Button,
+    Modal,
 } from '@togglecorp/toggle-ui';
+import produce from 'immer';
 import {
     removeNull,
     ObjectSchema,
@@ -31,9 +33,12 @@ import Loading from '#components/Loading';
 import NonFieldError from '#components/NonFieldError';
 import FormActions from '#components/FormActions';
 import NotificationContext from '#components/NotificationContext';
+import useBasicToggle from '#hooks/toggleBasicState';
 
 import { WithId } from '#utils/common';
 import CountryMultiSelectInput, { CountryOption } from '#components/selections/CountryMultiSelectInput';
+
+import GroupForm from '../GroupForm';
 
 import styles from './styles.css';
 
@@ -46,6 +51,8 @@ import {
     ResourceQueryVariables,
     ResourceGroupType,
     CountryType,
+    CreateResourceGroupMutation,
+    GroupsForResourceQuery,
 } from '#generated/types';
 
 const CREATE_RESOURCE = gql`
@@ -118,6 +125,17 @@ const GET_RESOURCE_BY_ID = gql`
     }
 `;
 
+const GET_GROUPS_LIST = gql`
+    query GroupsForResource {
+        resourceGroupList {
+            results {
+                name
+                id
+            }
+        }
+    }
+`;
+
 const getKeySelectorValue = (data: Group | Country) => data.id;
 
 const getLabelSelectorValue = (data: Group | Country) => data.name;
@@ -140,11 +158,8 @@ const schema: FormSchema = {
         countries: [requiredListCondition, arrayCondition],
     }),
 };
-
 interface ResourceFormProps {
     onResourceFormClose: () => void,
-    onGroupFormOpen: () => void,
-    groups: Group[] | undefined | null,
     id: string | undefined,
     handleRefetchResource: MutationUpdaterFn<CreateResourceMutation>;
     defaultCountryOption?: CountryOption | undefined | null;
@@ -153,12 +168,16 @@ interface ResourceFormProps {
 function ResourceForm(props: ResourceFormProps) {
     const {
         onResourceFormClose,
-        onGroupFormOpen,
-        groups,
         id,
         handleRefetchResource,
         defaultCountryOption,
     } = props;
+
+    const [
+        groupFormOpened,
+        handleGroupFormOpen,
+        handleGroupFormClose,
+    ] = useBasicToggle();
 
     const { user } = useContext(DomainContext);
     // FIXME: add permission for group and use it
@@ -170,9 +189,13 @@ function ResourceForm(props: ResourceFormProps) {
                 return {};
             }
             const country = defaultCountryOption.id;
-            return { countries: [country] };
+            return {
+                countries: [country],
+            };
         },
-        [defaultCountryOption],
+        [
+            defaultCountryOption,
+        ],
     );
 
     const {
@@ -195,6 +218,45 @@ function ResourceForm(props: ResourceFormProps) {
         setCountryOptions,
     ] = useState<CountryOption[] | undefined | null>(
         defaultCountryOption ? [defaultCountryOption] : undefined,
+    );
+
+    const {
+        data: groups,
+        // loading: groupsLoading,
+        // error: errorGroupsLoading,
+    } = useQuery<GroupsForResourceQuery>(GET_GROUPS_LIST);
+
+    const handleAddNewGroupInCache: MutationUpdaterFn<
+        CreateResourceGroupMutation
+    > = useCallback(
+        (cache, data) => {
+            const resourceGroup = data?.data?.createResourceGroup?.result;
+            if (!resourceGroup) {
+                return;
+            }
+
+            const cacheData = cache.readQuery<GroupsForResourceQuery>({
+                query: GET_GROUPS_LIST,
+            });
+
+            const updatedValue = produce(cacheData, (safeCacheData) => {
+                if (!safeCacheData?.resourceGroupList?.results) {
+                    return;
+                }
+                const { results } = safeCacheData.resourceGroupList;
+                results.push(resourceGroup);
+            });
+
+            if (updatedValue === cacheData) {
+                return;
+            }
+
+            cache.writeQuery({
+                query: GET_GROUPS_LIST,
+                data: updatedValue,
+            });
+        },
+        [],
     );
 
     const resourceVariables = useMemo(
@@ -306,6 +368,15 @@ function ResourceForm(props: ResourceFormProps) {
         },
     );
 
+    const handleNewGroupName = useCallback(
+        (groupName: string | undefined) => {
+            onValueChange(groupName, 'group');
+        },
+        [
+            onValueChange,
+        ],
+    );
+
     const handleSubmit = useCallback((finalValue: FormType) => {
         if (finalValue.id) {
             updateResource({
@@ -322,6 +393,8 @@ function ResourceForm(props: ResourceFormProps) {
         }
     }, [updateResource, createResource]);
 
+    const groupsList = groups?.resourceGroupList?.results;
+
     const loading = createResourceLoading
         || updateResourceLoading
         || resourceDataLoading;
@@ -329,82 +402,98 @@ function ResourceForm(props: ResourceFormProps) {
     const disabled = loading || errored;
 
     return (
-        <form
-            className={styles.resourceForm}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
-        >
-            {loading && <Loading absolute />}
-            <NonFieldError>
-                {error?.$internal}
-            </NonFieldError>
-            <TextInput
-                label="Name *"
-                name="name"
-                value={value.name}
-                onChange={onValueChange}
-                error={error?.fields?.name}
-                disabled={disabled}
-                autoFocus
-            />
-            <TextInput
-                label="URL *"
-                name="url"
-                value={value.url}
-                onChange={onValueChange}
-                error={error?.fields?.url}
-                disabled={disabled}
-            />
-            <SelectInput
-                label="Group"
-                actions={addResourcePermission && (
+        <>
+            <form
+                className={styles.resourceForm}
+                onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            >
+                {loading && <Loading absolute />}
+                <NonFieldError>
+                    {error?.$internal}
+                </NonFieldError>
+                <TextInput
+                    label="Name *"
+                    name="name"
+                    value={value.name}
+                    onChange={onValueChange}
+                    error={error?.fields?.name}
+                    disabled={disabled}
+                    autoFocus
+                />
+                <TextInput
+                    label="URL *"
+                    name="url"
+                    value={value.url}
+                    onChange={onValueChange}
+                    error={error?.fields?.url}
+                    disabled={disabled}
+                />
+                <SelectInput
+                    label="Group"
+                    actions={addResourcePermission && (
+                        <Button
+                            name={undefined}
+                            onClick={handleGroupFormOpen}
+                            transparent
+                            compact
+                            title="Add new group"
+                        >
+                            <IoMdAdd />
+                        </Button>
+                    )}
+                    name="group"
+                    options={groupsList}
+                    value={value.group}
+                    keySelector={getKeySelectorValue}
+                    labelSelector={getLabelSelectorValue}
+                    onChange={onValueChange}
+                    error={error?.fields?.group}
+                    disabled={disabled}
+                />
+                <CountryMultiSelectInput
+                    options={countryOptions}
+                    onOptionsChange={setCountryOptions}
+                    label="Countries *"
+                    name="countries"
+                    value={value.countries}
+                    onChange={onValueChange}
+                    error={error?.fields?.countries?.$internal}
+                    disabled={disabled}
+                    readOnly={!!defaultCountryOption}
+                />
+                <FormActions className={styles.actions}>
                     <Button
                         name={undefined}
-                        onClick={onGroupFormOpen}
-                        transparent
-                        compact
-                        title="Add new group"
+                        onClick={onResourceFormClose}
+                        disabled={disabled}
                     >
-                        <IoMdAdd />
+                        Cancel
                     </Button>
-                )}
-                name="group"
-                options={groups}
-                value={value.group}
-                keySelector={getKeySelectorValue}
-                labelSelector={getLabelSelectorValue}
-                onChange={onValueChange}
-                error={error?.fields?.group}
-                disabled={disabled}
-            />
-            <CountryMultiSelectInput
-                options={countryOptions}
-                onOptionsChange={setCountryOptions}
-                label="Countries *"
-                name="countries"
-                value={value.countries}
-                onChange={onValueChange}
-                error={error?.fields?.countries?.$internal}
-                disabled={disabled}
-                readOnly={!!defaultCountryOption}
-            />
-            <FormActions className={styles.actions}>
-                <Button
-                    name={undefined}
-                    onClick={onResourceFormClose}
-                    disabled={disabled}
+                    <Button
+                        name={undefined}
+                        variant="primary"
+                        type="submit"
+                        disabled={disabled || pristine}
+                    >
+                        Submit
+                    </Button>
+                </FormActions>
+            </form>
+            {groupFormOpened && (
+                <Modal
+                    heading="Add Group"
+                    onClose={handleGroupFormClose}
+                    size="small"
+                    freeHeight
                 >
-                    Cancel
-                </Button>
-                <Button
-                    name={undefined}
-                    variant="primary"
-                    type="submit"
-                    disabled={disabled || pristine}
-                >
-                    Submit
-                </Button>
-            </FormActions>
-        </form>
+                    <GroupForm
+                        onGroupFormClose={handleGroupFormClose}
+                        onAddNewGroupInCache={handleAddNewGroupInCache}
+                        handleNewGroupName={handleNewGroupName}
+                    />
+                </Modal>
+            )}
+        </>
     );
 }
 

--- a/src/components/lists/MyResources/ResourceForm/index.tsx
+++ b/src/components/lists/MyResources/ResourceForm/index.tsx
@@ -146,7 +146,7 @@ interface ResourceFormProps {
     onGroupFormOpen: () => void,
     groups: Group[] | undefined | null,
     id: string | undefined,
-    onAddNewResourceInCache: MutationUpdaterFn<CreateResourceMutation>;
+    handleRefetchResource: MutationUpdaterFn<CreateResourceMutation>;
     defaultCountryOption?: CountryOption | undefined | null;
 }
 
@@ -156,7 +156,7 @@ function ResourceForm(props: ResourceFormProps) {
         onGroupFormOpen,
         groups,
         id,
-        onAddNewResourceInCache,
+        handleRefetchResource,
         defaultCountryOption,
     } = props;
 
@@ -235,7 +235,7 @@ function ResourceForm(props: ResourceFormProps) {
     ] = useMutation<CreateResourceMutation, CreateResourceMutationVariables>(
         CREATE_RESOURCE,
         {
-            update: onAddNewResourceInCache,
+            update: handleRefetchResource,
             onCompleted: (response) => {
                 const { createResource: createResourceRes } = response;
                 if (!createResourceRes) {

--- a/src/components/lists/MyResources/ResourceForm/index.tsx
+++ b/src/components/lists/MyResources/ResourceForm/index.tsx
@@ -222,7 +222,8 @@ function ResourceForm(props: ResourceFormProps) {
     );
 
     const {
-        data: groups,
+        previousData,
+        data: groups = previousData,
         // loading: groupsLoading,
         // error: errorGroupsLoading,
     } = useQuery<GroupsForResourceQuery>(GET_GROUPS_LIST);
@@ -491,7 +492,7 @@ function ResourceForm(props: ResourceFormProps) {
                 >
                     <GroupForm
                         onAddNewGroupInCache={handleAddNewGroupInCache}
-                        handleNewGroupName={handleNewGroupName}
+                        onAddNewGroup={handleNewGroupName}
                     />
                 </Modal>
             )}

--- a/src/components/lists/MyResources/ResourceForm/index.tsx
+++ b/src/components/lists/MyResources/ResourceForm/index.tsx
@@ -213,6 +213,7 @@ function ResourceForm(props: ResourceFormProps) {
         notify,
         notifyGQLError,
     } = useContext(NotificationContext);
+
     const [
         countryOptions,
         setCountryOptions,
@@ -370,10 +371,12 @@ function ResourceForm(props: ResourceFormProps) {
 
     const handleNewGroupName = useCallback(
         (groupName: string | undefined) => {
+            handleGroupFormClose();
             onValueChange(groupName, 'group');
         },
         [
             onValueChange,
+            handleGroupFormClose,
         ],
     );
 
@@ -487,7 +490,6 @@ function ResourceForm(props: ResourceFormProps) {
                     freeHeight
                 >
                     <GroupForm
-                        onGroupFormClose={handleGroupFormClose}
                         onAddNewGroupInCache={handleAddNewGroupInCache}
                         handleNewGroupName={handleNewGroupName}
                     />

--- a/src/components/lists/MyResources/index.tsx
+++ b/src/components/lists/MyResources/index.tsx
@@ -84,6 +84,7 @@ function MyResources(props: MyResourcesProps) {
         previousData,
         data: resources = previousData,
         refetch: refetchResource,
+        // FIXME:
         // loading: resourcesLoading,
         // error: errorResourceLoading,
     } = useQuery<ResourcesQuery>(GET_RESOURCES_LIST, {

--- a/src/hooks/toggleBasicState.ts
+++ b/src/hooks/toggleBasicState.ts
@@ -5,18 +5,18 @@ export default function useBasicToggle(onReset?: () => void): [
     () => void,
     () => void,
 ] {
-    const [value, setValues] = useState(false);
+    const [value, setValue] = useState(false);
 
     const setAction = useCallback(() => {
-        setValues(true);
-    }, [setValues]);
+        setValue(true);
+    }, [setValue]);
 
     const resetAction = useCallback(() => {
         if (onReset) {
             onReset();
         }
-        setValues(false);
-    }, [setValues, onReset]);
+        setValue(false);
+    }, [setValue, onReset]);
 
     return [value, setAction, resetAction];
 }


### PR DESCRIPTION
## Addresses:
- Add fixes to my resource logic not refreshing instantly after new creation or update
- Feature to add new group name to the group-field of resource form

## Changes:
- Replace re-fetch logic of my resources
- Add functionality to add newly added group to the resource form instantly


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
