### PR TITLE
Fix sources field not disabled in figure-input

### DIFF
--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -604,9 +604,14 @@ function FigureInput(props: FigureInputProps) {
         [error?.fields?.country, error?.fields?.geoLocations],
     );
 
-    const diff = isDefined(totalValue) && isDefined(totalDisaggregatedValue)
-        ? totalValue - totalDisaggregatedValue
-        : 0;
+    const diff = useMemo(
+        () => (
+            isDefined(totalValue) && isDefined(totalDisaggregatedValue)
+                ? totalValue - totalDisaggregatedValue
+                : 0
+        ),
+        [totalDisaggregatedValue, totalValue],
+    );
 
     const selectedSources = useMemo(
         () => {
@@ -1082,7 +1087,7 @@ function FigureInput(props: FigureInputProps) {
                         value={value.sources}
                         name="sources"
                         error={error?.fields?.sources?.$internal}
-                        disabled={disabled}
+                        disabled={disabled || figureOptionsDisabled || eventNotChosen}
                         options={organizations}
                         onOptionsChange={setOrganizations}
                         readOnly={!editMode}


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/104#issue-1285633013

## Changes:
- Edit disabled mode for sources field on figure-input

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
