### PR TITLE
Add clear field option in the figure-input modal

### DIFF
--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -74,6 +74,8 @@ import {
     Figure_Terms as FigureTerms,
     Crisis_Type as CrisisType,
     Quantifier,
+    Date_Accuracy as DateAccuracy,
+    Displacement_Occurred as DisplacementOccurred,
 } from '#generated/types';
 import {
     isFlowCategory,
@@ -746,25 +748,23 @@ function FigureInput(props: FigureInputProps) {
         [selectedSources],
     );
 
-    const handleClearForm = useCallback((val) => {
-        console.log('Check clear form::>', val);
+    const handleClearForm = useCallback(() => {
         onChange((prevVal) => {
             if (!prevVal) {
                 return defaultValue;
             }
-            console.log('Check previous value::>', prevVal);
+            const dayAccuracy: DateAccuracy = 'DAY';
+            const unknownDisplacement: DisplacementOccurred = 'UNKNOWN';
             return {
-                ...prevVal,
-                event: prevVal.event,
-                figureCause: prevVal.figureCause,
-                quantifier: undefined,
-                term: undefined,
-                // figureCause: safeOption.eventType,
-                // violenceSubType: safeOption.violenceSubType?.id,
+                uuid: prevVal.uuid,
+                id: prevVal.id,
 
-                // disasterSubType: safeOption.disasterSubType?.id,
-
-                // otherSubType: safeOption.otherSubType?.id,
+                includeIdu: false,
+                isDisaggregated: false,
+                isHousingDestruction: false,
+                startDateAccuracy: dayAccuracy,
+                endDateAccuracy: dayAccuracy,
+                displacementOccurred: unknownDisplacement,
             };
         }, index);
     }, [
@@ -792,7 +792,7 @@ function FigureInput(props: FigureInputProps) {
                             onClick={handleClearForm}
                             disabled={disabled}
                         >
-                            Clear Form
+                            Clear
                         </Button>
                         <Button
                             name={index}

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -746,6 +746,32 @@ function FigureInput(props: FigureInputProps) {
         [selectedSources],
     );
 
+    const handleClearForm = useCallback((val) => {
+        console.log('Check clear form::>', val);
+        onChange((prevVal) => {
+            if (!prevVal) {
+                return defaultValue;
+            }
+            console.log('Check previous value::>', prevVal);
+            return {
+                ...prevVal,
+                event: prevVal.event,
+                figureCause: prevVal.figureCause,
+                quantifier: undefined,
+                term: undefined,
+                // figureCause: safeOption.eventType,
+                // violenceSubType: safeOption.violenceSubType?.id,
+
+                // disasterSubType: safeOption.disasterSubType?.id,
+
+                // otherSubType: safeOption.otherSubType?.id,
+            };
+        }, index);
+    }, [
+        onChange,
+        index,
+    ]);
+
     return (
         <CollapsibleContent
             elementRef={elementRef}
@@ -760,13 +786,22 @@ function FigureInput(props: FigureInputProps) {
                 contentClassName={styles.sectionContent}
                 subSection
                 actions={editMode && (
-                    <Button
-                        name={index}
-                        onClick={onRemove}
-                        disabled={disabled}
-                    >
-                        Remove
-                    </Button>
+                    <>
+                        <Button
+                            name={index}
+                            onClick={handleClearForm}
+                            disabled={disabled}
+                        >
+                            Clear Form
+                        </Button>
+                        <Button
+                            name={index}
+                            onClick={onRemove}
+                            disabled={disabled}
+                        >
+                            Remove
+                        </Button>
+                    </>
                 )}
             >
                 <NonFieldError>


### PR DESCRIPTION
## Addresses:
- https://github.com/idmc-labs/helix2.0-meta/issues/91#issue-1278199349

## Changes:
- Add a clear button that clears up the figure input modal fields

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
