### PR TITLE
Add stock date columns in figures table

### DIFF
--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -109,8 +109,8 @@ const FIGURE_LIST = gql`
                 totalFigures
                 term
                 termDisplay
-                endDate
-                startDate
+                flowEndDate
+                flowStartDate
                 stockDate
                 stockReportingDate
             }
@@ -316,15 +316,15 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(
-                    'start_date',
+                    'flow_start_date',
                     'Start Date',
-                    (item) => item.startDate,
+                    (item) => item.flowStartDate,
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(
-                    'end_date',
+                    'flow_end_date',
                     'End Date',
-                    (item) => item.endDate,
+                    (item) => item.flowEndDate,
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -111,6 +111,8 @@ const FIGURE_LIST = gql`
                 termDisplay
                 endDate
                 startDate
+                stockDate
+                stockReportingDate
             }
         }
     }
@@ -323,6 +325,18 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'end_date',
                     'End Date',
                     (item) => item.endDate,
+                    { sortable: true },
+                ),
+                createDateColumn<FigureFields, string>(
+                    'stock_date',
+                    'Stock Date',
+                    (item) => item.stockDate,
+                    { sortable: true },
+                ),
+                createDateColumn<FigureFields, string>(
+                    'stock_reporting_date',
+                    'Stock Reporting Date',
+                    (item) => item.stockReportingDate,
                     { sortable: true },
                 ),
                 eventColumnHidden

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -132,8 +132,8 @@ export const FIGURE_LIST = gql`
                 totalFigures
                 term
                 termDisplay
-                endDate
-                startDate
+                flowEndDate
+                flowStartDate
                 stockDate
                 stockReportingDate
             }
@@ -331,15 +331,15 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(
-                    'start_date',
+                    'flow_start_date',
                     'Start Date',
-                    (item) => item.startDate,
+                    (item) => item.flowStartDate,
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(
-                    'end_date',
+                    'flow_end_date',
                     'End Date',
-                    (item) => item.endDate,
+                    (item) => item.flowEndDate,
                     { sortable: true },
                 ),
                 createDateColumn<FigureFields, string>(

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -134,6 +134,8 @@ export const FIGURE_LIST = gql`
                 termDisplay
                 endDate
                 startDate
+                stockDate
+                stockReportingDate
             }
         }
     }
@@ -338,6 +340,18 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'end_date',
                     'End Date',
                     (item) => item.endDate,
+                    { sortable: true },
+                ),
+                createDateColumn<FigureFields, string>(
+                    'stock_date',
+                    'Stock Date',
+                    (item) => item.stockDate,
+                    { sortable: true },
+                ),
+                createDateColumn<FigureFields, string>(
+                    'stock_reporting_date',
+                    'Stock Reporting Date',
+                    (item) => item.stockReportingDate,
                     { sortable: true },
                 ),
                 createLinkColumn<FigureFields, string>(

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -91,8 +91,10 @@ const GET_REPORT_FIGURES = gql`
                     totalFigures
                     term
                     termDisplay
-                    endDate
-                    startDate
+                    flowEndDate
+                    flowStartDate
+                    stockDate
+                    stockReportingDate
                 }
                 page
                 pageSize
@@ -306,15 +308,27 @@ function ReportFigureTable(props: ReportFigureProps) {
                 { sortable: true },
             ),
             createDateColumn<ReportFigureFields, string>(
-                'start_date',
+                'flow_start_date',
                 'Start Date',
-                (item) => item.startDate,
+                (item) => item.flowStartDate,
                 { sortable: true },
             ),
             createDateColumn<ReportFigureFields, string>(
-                'end_date',
+                'flow_end_date',
                 'End Date',
-                (item) => item.endDate,
+                (item) => item.flowEndDate,
+                { sortable: true },
+            ),
+            createDateColumn<ReportFigureFields, string>(
+                'stock_date',
+                'Stock Date',
+                (item) => item.stockDate,
+                { sortable: true },
+            ),
+            createDateColumn<ReportFigureFields, string>(
+                'stock_reporting_date',
+                'Stock Reporting Date',
+                (item) => item.stockReportingDate,
                 { sortable: true },
             ),
             createLinkColumn<ReportFigureFields, string>(


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/154

## Depends on:
- https://github.com/idmc-labs/helix-server/pull/308/files

## Changes:
- Addition of stock_date and stock_reporting_date in figureList query
- Addition of columns in figure table

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
