### PR TITLE
Make countries field non required

### DIFF
--- a/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
+++ b/src/views/Organizations/OrganizationTable/OrganizationForm/index.tsx
@@ -14,7 +14,6 @@ import {
     removeNull,
     idCondition,
     requiredStringCondition,
-    requiredListCondition,
     arrayCondition,
     requiredCondition,
 } from '@togglecorp/toggle-form';
@@ -180,7 +179,7 @@ const schema: FormSchema = {
         name: [requiredStringCondition],
         methodology: [requiredStringCondition],
         category: [requiredCondition],
-        countries: [requiredListCondition, arrayCondition],
+        countries: [arrayCondition],
     }),
 };
 
@@ -458,7 +457,7 @@ function OrganizationForm(props: OrganizationFormProps) {
                 />
             </Row>
             <CountryMultiSelectInput
-                label="Countries *"
+                label="Countries"
                 name="countries"
                 options={countries}
                 onOptionsChange={setCountries}


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/152

## Depends on: 
- server: https://github.com/idmc-labs/helix-server/pull/320#issue-1326855344

## Changes:
- Make countries field not required in the organization form

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
