### PR TITLE
Fix the issue by adding separate crisis id

### DIFF
--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -251,6 +251,9 @@ function EventsTable(props: EventsProps) {
             qaRules,
             ignoreQa,
             ...eventQueryFilters,
+            crisisByIds: crisisId
+                ? [crisisId]
+                : eventQueryFilters?.crisisByIds,
         }),
         [
             ordering,
@@ -259,6 +262,7 @@ function EventsTable(props: EventsProps) {
             qaRules,
             ignoreQa,
             eventQueryFilters,
+            crisisId,
         ],
     );
 


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/177#issue-1325995699

## Changes:
- Fix the issue of events table in crisis page by adding extra crisisByIds argument in events query variable

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
