### PR TITLE
Enable auto-selected fields for QA filters

### DIFF
--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -47,18 +47,16 @@ const ME = gql`
             fullName
             portfolioRole
             portfolios {
-                results {
+                id
+                role
+                monitoringSubRegion {
                     id
-                    role
-                    monitoringSubRegion {
+                    name
+                    countries {
                         id
-                        name
-                        countries {
-                            id
-                            idmcShortName
-                            boundingBox
-                            iso2
-                        }
+                        idmcShortName
+                        boundingBox
+                        iso2
                     }
                 }
             }
@@ -131,7 +129,7 @@ function Multiplexer(props: Props) {
             }
             const { permissions, ...others } = user;
             const newPermissions = transformPermissions(permissions ?? []);
-            const newUser = {
+            const newUser: User = {
                 ...others,
                 permissions: newPermissions,
             };

--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -46,6 +46,22 @@ const ME = gql`
           id
           fullName
           portfolioRole
+          portfolios {
+            results {
+              id
+              role
+              monitoringSubRegion {
+                id
+                name
+                countries {
+                    id
+                    idmcShortName
+                    boundingBox
+                    iso2
+                }
+              }
+            }
+          }
           permissions {
               action
               entities
@@ -108,16 +124,17 @@ function Multiplexer(props: Props) {
         [key: string]: Notification;
     }>({});
 
-    const userWithPermissions: User | undefined = useMemo(
+    const userWithPermissions = useMemo(
         () => {
             if (!user) {
                 return undefined;
             }
             const { permissions, ...others } = user;
             const newPermissions = transformPermissions(permissions ?? []);
-            const newUser = {
+            const newUser: User = {
                 ...others,
                 permissions: newPermissions,
+                portfolios: undefined,
             };
             return newUser;
         },

--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -42,31 +42,31 @@ const notificationVariantToClassNameMap: { [key in NotificationVariant]: string 
 
 const ME = gql`
     query Me {
-      me {
-          id
-          fullName
-          portfolioRole
-          portfolios {
-            results {
-              id
-              role
-              monitoringSubRegion {
-                id
-                name
-                countries {
+        me {
+            id
+            fullName
+            portfolioRole
+            portfolios {
+                results {
                     id
-                    idmcShortName
-                    boundingBox
-                    iso2
+                    role
+                    monitoringSubRegion {
+                        id
+                        name
+                        countries {
+                            id
+                            idmcShortName
+                            boundingBox
+                            iso2
+                        }
+                    }
                 }
-              }
             }
-          }
-          permissions {
-              action
-              entities
-          }
-      }
+            permissions {
+                action
+                entities
+            }
+        }
     }
 `;
 
@@ -125,16 +125,15 @@ function Multiplexer(props: Props) {
     }>({});
 
     const userWithPermissions = useMemo(
-        () => {
+        (): User | undefined => {
             if (!user) {
                 return undefined;
             }
             const { permissions, ...others } = user;
             const newPermissions = transformPermissions(permissions ?? []);
-            const newUser: User = {
+            const newUser = {
                 ...others,
                 permissions: newPermissions,
-                portfolios: undefined,
             };
             return newUser;
         },

--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -45,6 +45,7 @@ const ME = gql`
       me {
           id
           fullName
+          portfolioRole
           permissions {
               action
               entities

--- a/src/components/tables/EventsEntriesFiguresTable/EventsFilter/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/EventsFilter/index.tsx
@@ -209,7 +209,7 @@ function EventsFilter(props: EventsFilterProps) {
 
     const regionalCoordinatorCountries = useMemo(
         () => (
-            user?.portfolios?.results
+            user?.portfolios
                 ?.find((element) => element.role === regionalCoordinator)
                 ?.monitoringSubRegion?.countries ?? undefined
         ),

--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -348,6 +348,7 @@ function EventsTable(props: EventsProps) {
                     onFilterChange={onFilterChange}
                     createdBySelectionDisabled={false}
                     countriesSelectionDisabled={false}
+                    qaMode={qaMode}
                 />
             )}
         >

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,7 +68,7 @@ export interface User {
     fullName: string;
     id: string;
     // eslint-disable-next-line camelcase
-    role?: User_Role;
+    portfolioRole?: User_Role;
     permissions?: {
         // eslint-disable-next-line camelcase
         [entityKey in Permission_Entity]?: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ import {
     Permission_Action, // eslint-disable-line camelcase
     Permission_Entity, // eslint-disable-line camelcase
     User_Role, // eslint-disable-line camelcase
+    PortfolioListType,
 } from '#generated/types';
 
 export type MakeRequired<T, K extends string> = Omit<T, K> & Required<T>;
@@ -76,6 +77,7 @@ export interface User {
             [key in Permission_Action]?: boolean;
         };
     };
+    portfolios?: PortfolioListType;
 }
 
 export type NotificationVariant = 'default' | 'success' | 'error';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import {
     Permission_Action, // eslint-disable-line camelcase
     Permission_Entity, // eslint-disable-line camelcase
     User_Role, // eslint-disable-line camelcase
-    PortfolioListType,
+    MeQuery,
 } from '#generated/types';
 
 export type MakeRequired<T, K extends string> = Omit<T, K> & Required<T>;
@@ -70,7 +70,7 @@ export interface User {
     id: string;
     // eslint-disable-next-line camelcase
     portfolioRole?: User_Role;
-    portfolios?: PortfolioListType;
+    portfolios?: NoNull<MeQuery['me']>['portfolios'];
     permissions?: {
         // eslint-disable-next-line camelcase
         [entityKey in Permission_Entity]?: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,7 @@ export interface User {
     id: string;
     // eslint-disable-next-line camelcase
     portfolioRole?: User_Role;
+    portfolios?: PortfolioListType;
     permissions?: {
         // eslint-disable-next-line camelcase
         [entityKey in Permission_Entity]?: {
@@ -77,7 +78,6 @@ export interface User {
             [key in Permission_Action]?: boolean;
         };
     };
-    portfolios?: PortfolioListType;
 }
 
 export type NotificationVariant = 'default' | 'success' | 'error';

--- a/src/views/SignIn/index.tsx
+++ b/src/views/SignIn/index.tsx
@@ -43,18 +43,16 @@ const LOGIN = gql`
                 fullName
                 portfolioRole
                 portfolios {
-                    results {
+                    id
+                    role
+                    monitoringSubRegion {
                         id
-                        role
-                        monitoringSubRegion {
+                        name
+                        countries {
                             id
-                            name
-                            countries {
-                                id
-                                idmcShortName
-                                boundingBox
-                                iso2
-                            }
+                            idmcShortName
+                            boundingBox
+                            iso2
                         }
                     }
                 }

--- a/src/views/SignIn/index.tsx
+++ b/src/views/SignIn/index.tsx
@@ -36,22 +36,38 @@ import styles from './styles.css';
 const HCaptchaSitekey = process.env.REACT_APP_HCATPCHA_SITEKEY as string;
 
 const LOGIN = gql`
-  mutation Login($input: LoginInputType!) {
-    login(data: $input) {
-      result {
-        email
-        id
-        fullName
-        permissions {
-            action
-            entities
+    mutation Login($input: LoginInputType!) {
+        login(data: $input) {
+            result {
+                id
+                fullName
+                portfolioRole
+                portfolios {
+                    results {
+                        id
+                        role
+                        monitoringSubRegion {
+                            id
+                            name
+                            countries {
+                                id
+                                idmcShortName
+                                boundingBox
+                                iso2
+                            }
+                        }
+                    }
+                }
+                permissions {
+                    action
+                    entities
+                }
+            }
+            captchaRequired
+            errors
+            ok
         }
-      }
-      captchaRequired
-      errors
-      ok
     }
-  }
 `;
 
 type LoginFormFields = LoginInputType;


### PR DESCRIPTION
## Addresses:
- issue: https://github.com/idmc-labs/helix2.0-meta/issues/172

## Depends on:
- server branch: https://github.com/idmc-labs/helix-server/pull/323#issue-1338610590

## Changes:
- Add a feature to pre-select options in the QA filter based upon the condition that if the user is Regional-Coordinator or Monitoring-Expert 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
