### PR TITLE
Enable editing document and url fields on Entry

### DIFF
--- a/src/components/GeoInput/index.tsx
+++ b/src/components/GeoInput/index.tsx
@@ -352,10 +352,41 @@ function isValidGeoLocation(value: GeoLocation): value is GoodGeoLocation {
     return isTruthyString(value.osmId) && isDefined(value.lon) && isDefined(value.lat);
 }
 
+// The mapping is created from the information available here:
+// https://github.com/OSMNames/OSMNames/blob/master/osmnames/prepare_data/set_place_ranks.sql
+const mappings: {
+    [key: string]: OsmAccuracy | undefined;
+} = {
+    continent: 'ADM0',
+
+    country: 'ADM0',
+
+    country_region: 'ADM1',
+    state: 'ADM1',
+
+    state_district: 'ADM2',
+    county: 'ADM2',
+    administrative: 'ADM2',
+
+    town: 'ADM3',
+    city: 'ADM3',
+    district: 'ADM3',
+    city_district: 'ADM3',
+    village: 'ADM3',
+    hamlet: 'ADM3',
+    municipality: 'ADM3',
+};
+const defaultAccuracy: OsmAccuracy = 'POINT';
+function inferAccuracy(type: string | undefined | null): OsmAccuracy {
+    if (!type) {
+        return defaultAccuracy;
+    }
+    return mappings[type] || defaultAccuracy;
+}
+
 function convertToGeoLocation(item: LookupData, omitIdentifier?: boolean): GeoLocation {
     const properties = removeNull(item);
     const defaultIdentifier: Identifier = 'ORIGIN';
-    const defaultAccuracy: OsmAccuracy = 'ADM1';
 
     const newValue: GeoLocation = {
         uuid: uuidv4(),
@@ -384,7 +415,7 @@ function convertToGeoLocation(item: LookupData, omitIdentifier?: boolean): GeoLo
 
         moved: false,
         identifier: omitIdentifier ? undefined : defaultIdentifier,
-        accuracy: defaultAccuracy,
+        accuracy: inferAccuracy(properties.type),
     };
     return newValue;
 }

--- a/src/views/Entry/EntryForm/AgeInput/index.tsx
+++ b/src/views/Entry/EntryForm/AgeInput/index.tsx
@@ -33,7 +33,7 @@ import styles from './styles.css';
 type AgeInputValue = PartialForm<AgeFormProps>;
 
 const defaultValue: AgeInputValue = {
-    uuid: 'hari',
+    uuid: 'random-uuid',
 };
 
 interface AgeInputProps {

--- a/src/views/Entry/EntryForm/DetailsInput/index.tsx
+++ b/src/views/Entry/EntryForm/DetailsInput/index.tsx
@@ -70,7 +70,7 @@ interface DetailsInputProps<K extends string> {
     sourcePreview?: SourcePreview;
     attachment?: Attachment;
 
-    entryId: string | undefined;
+    // entryId: string | undefined;
     onUrlProcess: (value: string) => void;
     onRemoveUrl: () => void;
     onRemoveAttachment: () => void;
@@ -95,7 +95,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
         disabled: disabledFromProps,
         sourcePreview,
         // attachmentProcessed,
-        entryId,
+        // entryId,
         onRemoveUrl,
         onRemoveAttachment,
         onUrlProcess,
@@ -118,6 +118,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
     const attachmentProcessed = !!attachment;
     const urlProcessed = !!sourcePreview;
     const processed = attachmentProcessed || urlProcessed;
+
     const disabled = disabledFromProps || !processed;
 
     const handleProcessUrlButtonClick = React.useCallback(() => {
@@ -191,7 +192,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
                                 </Button>
                             )}
                         />
-                        {urlProcessed && !entryId && (
+                        {urlProcessed && editMode && (
                             <Button
                                 className={styles.removalButtons}
                                 name={undefined}
@@ -237,7 +238,7 @@ function DetailsInput<K extends string>(props: DetailsInputProps<K>) {
                                 or Upload a Document
                             </FileUploader>
                         )}
-                        {attachmentProcessed && !entryId && (
+                        {attachmentProcessed && editMode && (
                             <Button
                                 className={styles.removalButtons}
                                 name={undefined}

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -147,6 +147,7 @@ function generateFigureTitle(
     startDateInfo?: string | undefined,
     includeIdu?: boolean | undefined,
     isHousingDestruction?: boolean | undefined,
+    isTermDestroyedHousing?: boolean | undefined,
 ) {
     const locationField = locationInfo || '(Location)';
     const countryField = countryInfo || '(Country)';
@@ -159,11 +160,13 @@ function generateFigureTitle(
 
     return [
         `${locationField},  ${countryField}`,
-        `${totalFigureField} ${figureTypeField}`,
+        isTermDestroyedHousing
+            ? `${totalFigureField} ${figureTypeField} (DH)`
+            : `${totalFigureField} ${figureTypeField}`,
         figureRoleField,
         `${figureCauseType}, ${causeField}`,
         includeIdu ? 'IDU' : undefined,
-        isHousingDestruction ? 'Housing destruction' : undefined,
+        isHousingDestruction ? 'Housing destruction Toggle On' : undefined,
         startDateField,
     ].filter(isDefined).join(' - ');
 }
@@ -554,6 +557,9 @@ function FigureInput(props: FigureInputProps) {
                 ?.find((causeOption) => causeOption.name === value.figureCause)
                 ?.description;
 
+            const figureTerm = value.term as (FigureTerms | undefined);
+            const isTermDestroyedHousing = figureTerm === 'DESTROYED_HOUSING';
+
             return generateFigureTitle(
                 locationsText,
                 currentCountry?.idmcShortName,
@@ -566,6 +572,7 @@ function FigureInput(props: FigureInputProps) {
 
                 value.includeIdu,
                 value.isHousingDestruction,
+                isTermDestroyedHousing,
             );
         },
         [
@@ -745,9 +752,7 @@ function FigureInput(props: FigureInputProps) {
             sortedLocations.map((loc) => loc.name),
         ).join(', ');
 
-        const totalFigure = value.unit === household
-            ? calculateHouseHoldSize(value.reported, value.householdSize)
-            : value.reported;
+        const totalFigure = value.reported;
 
         let mainTrigger: string | undefined;
         if (isDefined(value.figureCause)) {
@@ -840,7 +845,6 @@ function FigureInput(props: FigureInputProps) {
         value.disasterSubType,
         value.otherSubType,
         value.violenceSubType,
-        value.householdSize,
     ]);
 
     const handleStartDateChange = useCallback((val: string | undefined) => {

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -811,6 +811,9 @@ function FigureInput(props: FigureInputProps) {
                         // NOTE: Let's not lowercase organization names
                         return name;
                     }
+                    if (organizationKind.name === 'National/Regional Disaster Authority') {
+                        return 'national/regional disaster authorities';
+                    }
                     return organizationKind.name.toLowerCase();
                 }) ?? [],
             (organizationKind) => organizationKind,

--- a/src/views/Entry/EntryForm/GeoLocationInput/index.tsx
+++ b/src/views/Entry/EntryForm/GeoLocationInput/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { _cs } from '@togglecorp/fujs';
 
 import {
     TextInput,
@@ -12,7 +13,6 @@ import {
     StateArg,
 } from '@togglecorp/toggle-form';
 
-import Section from '#components/Section';
 import NonFieldError from '#components/NonFieldError';
 import TrafficLightInput from '#components/TrafficLightInput';
 import Row from '#components/Row';
@@ -29,10 +29,12 @@ import {
     EntryReviewStatus,
 } from '../types';
 
+import styles from './styles.css';
+
 type GeoLocationInputValue = PartialForm<GeoLocationFormProps>;
 
 const defaultValue: GeoLocationInputValue = {
-    uuid: 'hari',
+    uuid: 'random-uuid',
 };
 
 interface GeoLocationInputProps {
@@ -77,35 +79,17 @@ function GeoLocationInput(props: GeoLocationInputProps) {
     const geoLocationId = value.id;
 
     return (
-        <Section
-            className={className}
-            heading={value.displayName}
-            subSection
-            actions={editMode && (
-                <Button
-                    onClick={onRemove}
-                    name={index}
-                    disabled={disabled}
-                >
-                    Remove
-                </Button>
-            )}
+        <div
+            className={_cs(className, styles.locationInput)}
         >
             <NonFieldError>
                 {error?.$internal}
             </NonFieldError>
             <Row>
                 <TextInput
-                    label="District"
-                    name="district"
-                    value={value.state}
-                    disabled={disabled}
-                    readOnly
-                />
-                <TextInput
-                    label="Town"
-                    name="town"
-                    value={value.city}
+                    label="Location"
+                    name="location"
+                    value={value.displayName}
                     disabled={disabled}
                     readOnly
                 />
@@ -147,8 +131,19 @@ function GeoLocationInput(props: GeoLocationInputProps) {
                         />
                     )}
                 />
+                {editMode && (
+                    <Button
+                        className={styles.removeButton}
+                        onClick={onRemove}
+                        name={index}
+                        disabled={disabled}
+                        transparent
+                    >
+                        Remove
+                    </Button>
+                )}
             </Row>
-        </Section>
+        </div>
     );
 }
 

--- a/src/views/Entry/EntryForm/GeoLocationInput/styles.css
+++ b/src/views/Entry/EntryForm/GeoLocationInput/styles.css
@@ -1,0 +1,12 @@
+.location-input {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-medium);
+
+    .remove-button {
+        align-self: flex-start;
+        flex-basis: unset;
+        flex-grow: unset;
+        flex-shrink: 0;
+    }
+}

--- a/src/views/Entry/EntryForm/index.tsx
+++ b/src/views/Entry/EntryForm/index.tsx
@@ -271,6 +271,7 @@ function EntryForm(props: EntryFormProps) {
                             document: result.id,
                         },
                     }));
+                    onPristineSet(false);
                 }
             },
             onError: (err) => {
@@ -306,6 +307,7 @@ function EntryForm(props: EntryFormProps) {
                             preview: result.id,
                         },
                     }));
+                    onPristineSet(false);
                 }
             },
             onError: (err) => {
@@ -536,24 +538,13 @@ function EntryForm(props: EntryFormProps) {
     );
     const handleSubmit = useCallback((finalValue: PartialFormValues) => {
         const completeValue = finalValue as FormValues;
-
-        const {
-            // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-            url: unusedUrl,
-            // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-            preview: unusedSourcePreview,
-            // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-            document: unusedDocument,
-            ...otherDetails
-        } = completeValue.details;
-
         if (entryId) {
             const entry = {
                 id: entryId,
                 reviewers: completeValue.reviewers,
                 figures: completeValue.figures,
-                ...otherDetails,
                 ...completeValue.analysis,
+                ...completeValue.details,
             } as WithId<EntryFormFields>;
 
             updateEntry({
@@ -597,7 +588,8 @@ function EntryForm(props: EntryFormProps) {
                     url: undefined,
                 },
             }));
-        }, [setSourcePreview, onValueSet],
+            onPristineSet(false);
+        }, [setSourcePreview, onValueSet, onPristineSet],
     );
 
     const handleAttachmentRemove = useCallback(
@@ -610,8 +602,9 @@ function EntryForm(props: EntryFormProps) {
                     document: undefined,
                 },
             }));
+            onPristineSet(false);
         },
-        [setAttachment, onValueSet],
+        [setAttachment, onValueSet, onPristineSet],
     );
 
     const handleAttachmentProcess = useCallback(
@@ -811,7 +804,7 @@ function EntryForm(props: EntryFormProps) {
                             onChange={onValueChange}
                             error={error?.fields?.details}
                             disabled={loading}
-                            entryId={entryId}
+                            // entryId={entryId}
                             sourcePreview={preview}
                             attachment={attachment}
                             onAttachmentProcess={handleAttachmentProcess}


### PR DESCRIPTION
Related to https://github.com/idmc-labs/helix2.0-meta/issues/110
Related to https://github.com/idmc-labs/helix2.0-meta/issues/170
Related to https://github.com/idmc-labs/helix2.0-meta/issues/183
Related to https://github.com/idmc-labs/helix2.0-meta/issues/148 

# Other changes

- Add a mapping to infer accuracy on Location
- Show name instead of district and town on Location
- Show 'DH' if term is destroyed housing on figure title

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments