### PR TITLE
Add multiple columns for figure tables

### DIFF
--- a/src/components/selections/OrganizationMultiSelectInput/index.tsx
+++ b/src/components/selections/OrganizationMultiSelectInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 import {
     useQuery,
 } from '@apollo/client';
@@ -11,7 +11,7 @@ import SearchMultiSelectInputWithChip from '#components/SearchMultiSelectInputWi
 
 import useDebouncedValue from '#hooks/useDebouncedValue';
 import DomainContext from '#components/DomainContext';
-import { GetOrganizationQuery, GetOrganizationQueryVariables } from '#generated/types';
+import { GetOrganizationQuery } from '#generated/types';
 
 import { ORGANIZATION } from '../OrganizationSelectInput/index';
 
@@ -33,13 +33,18 @@ function labelSelector(org: OrganizationOption) {
 type Def = { containerClassName?: string };
 type MultiSelectInputProps<
     K extends string,
-> = SearchMultiSelectInputProps<
-    string,
-    K,
-    OrganizationOption,
-    Def,
-    'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
-    > & { chip?: boolean, optionEditable?: boolean, onOptionEdit?: (value: string) => void };
+    > = SearchMultiSelectInputProps<
+        string,
+        K,
+        OrganizationOption,
+        Def,
+        'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
+    > & {
+        chip?: boolean,
+        optionEditable?: boolean,
+        onOptionEdit?: (value: string) => void,
+        country?: string
+    };
 
 function OrganizationMultiSelectInput<K extends string>(props: MultiSelectInputProps<K>) {
     const {
@@ -47,6 +52,7 @@ function OrganizationMultiSelectInput<K extends string>(props: MultiSelectInputP
         chip,
         optionEditable,
         onOptionEdit,
+        country,
         ...otherProps
     } = props;
 
@@ -55,19 +61,16 @@ function OrganizationMultiSelectInput<K extends string>(props: MultiSelectInputP
 
     const debouncedSearchText = useDebouncedValue(searchText);
 
-    const searchVariable = useMemo(
-        (): GetOrganizationQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: 'name' }
-        ),
-        [debouncedSearchText],
-    );
-
     const {
         loading,
         previousData,
         data = previousData,
     } = useQuery<GetOrganizationQuery>(ORGANIZATION, {
-        variables: searchVariable,
+        variables: {
+            search: debouncedSearchText,
+            ordering: debouncedSearchText ? undefined : 'name',
+            countries: country ? [country] : undefined,
+        },
         skip: !opened,
     });
 

--- a/src/components/selections/OrganizationSelectInput/index.tsx
+++ b/src/components/selections/OrganizationSelectInput/index.tsx
@@ -15,8 +15,8 @@ import { GetOrganizationQuery, GetOrganizationQueryVariables } from '#generated/
 import styles from './styles.css';
 
 export const ORGANIZATION = gql`
-    query GetOrganization($search: String, $ordering: String) {
-        organizationList(name_Unaccent_Icontains: $search, ordering: $ordering) {
+    query GetOrganization($search: String, $ordering: String, $countries: [ID!]) {
+        organizationList(name_Unaccent_Icontains: $search, ordering: $ordering, countries: $countries) {
             totalCount
             results {
                 id

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -79,6 +79,7 @@ const FIGURE_LIST = gql`
                     fullName
                 }
                 geolocations
+                sourcesReliability
                 category
                 categoryDisplay
                 country {
@@ -272,6 +273,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'geolocations',
                     'Location',
                     (item) => item.geolocations,
+                    { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
+                    'sources_reliability',
+                    'Sources Reliability',
+                    (item) => item.sourcesReliability,
                     { sortable: true },
                 ),
                 createTextColumn<FigureFields, string>(

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -78,6 +78,7 @@ const FIGURE_LIST = gql`
                     id
                     fullName
                 }
+                geolocations
                 category
                 categoryDisplay
                 country {
@@ -113,6 +114,8 @@ const FIGURE_LIST = gql`
                 flowStartDate
                 stockDate
                 stockReportingDate
+                includeIdu
+                isHousingDestruction
             }
         }
     }
@@ -266,6 +269,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                         { sortable: true },
                     ),
                 createTextColumn<FigureFields, string>(
+                    'geolocations',
+                    'Location',
+                    (item) => item.geolocations,
+                    { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
                     'event__event_type',
                     'Cause',
                     (item) => item.event?.eventTypeDisplay,
@@ -338,6 +347,21 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'Stock Reporting Date',
                     (item) => item.stockReportingDate,
                     { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
+                    'include_idu',
+                    'Excerpt IDU',
+                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                ),
+                createTextColumn<FigureFields, string>(
+                    'is_housing_destruction',
+                    'Housing Destruction',
+                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
+                ),
+                createTextColumn<FigureFields, string>(
+                    'figure_typology',
+                    'Figure Type',
+                    (item) => item.figureTypology,
                 ),
                 eventColumnHidden
                     ? undefined

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -339,6 +339,8 @@ function FigureInput(props: FigureInputProps) {
         otherSubTypeOptions,
     } = props;
 
+    console.log('Organization List::>>>', organizations);
+
     const { notify } = useContext(NotificationContext);
     const { user } = useContext(DomainContext);
 
@@ -1462,6 +1464,7 @@ function FigureInput(props: FigureInputProps) {
                         name="sources"
                         error={error?.fields?.sources?.$internal}
                         disabled={disabled || figureOptionsDisabled || eventNotChosen}
+                        country={value.country}
                         options={organizations}
                         onOptionsChange={setOrganizations}
                         readOnly={!editMode}

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -105,6 +105,7 @@ export const FIGURE_LIST = gql`
                 category
                 categoryDisplay
                 geolocations
+                sourcesReliability
                 country {
                     id
                     idmcShortName
@@ -287,6 +288,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'geolocations',
                     'Location',
                     (item) => item.geolocations,
+                    { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
+                    'sources_reliability',
+                    'Sources Reliability',
+                    (item) => item.sourcesReliability,
                     { sortable: true },
                 ),
                 createTextColumn<FigureFields, string>(

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -104,6 +104,7 @@ export const FIGURE_LIST = gql`
                 }
                 category
                 categoryDisplay
+                geolocations
                 country {
                     id
                     idmcShortName
@@ -136,6 +137,8 @@ export const FIGURE_LIST = gql`
                 flowStartDate
                 stockDate
                 stockReportingDate
+                includeIdu
+                isHousingDestruction
             }
         }
     }
@@ -281,6 +284,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createTextColumn<FigureFields, string>(
+                    'geolocations',
+                    'Location',
+                    (item) => item.geolocations,
+                    { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
                     'event__event_type',
                     'Cause',
                     (item) => item.event?.eventTypeDisplay,
@@ -353,6 +362,16 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     'Stock Reporting Date',
                     (item) => item.stockReportingDate,
                     { sortable: true },
+                ),
+                createTextColumn<FigureFields, string>(
+                    'include_idu',
+                    'Excerpt IDU',
+                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                ),
+                createTextColumn<FigureFields, string>(
+                    'is_housing_destruction',
+                    'Housing Destruction',
+                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
                 ),
                 createLinkColumn<FigureFields, string>(
                     'event__name',

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -66,6 +66,9 @@ const GET_REPORT_FIGURES = gql`
                         id
                         idmcShortName
                     }
+                    includeIdu
+                    isHousingDestruction
+                    geolocations
                     entry {
                         id
                         oldId
@@ -269,6 +272,12 @@ function ReportFigureTable(props: ReportFigureProps) {
                 { sortable: true },
             ),
             createTextColumn<ReportFigureFields, string>(
+                'geolocations',
+                'Location',
+                (item) => item.geolocations,
+                { sortable: true },
+            ),
+            createTextColumn<ReportFigureFields, string>(
                 'country__idmc_short_name',
                 'Country',
                 (item) => item.country?.idmcShortName,
@@ -330,6 +339,16 @@ function ReportFigureTable(props: ReportFigureProps) {
                 'Stock Reporting Date',
                 (item) => item.stockReportingDate,
                 { sortable: true },
+            ),
+            createTextColumn<ReportFigureFields, string>(
+                'include_idu',
+                'Excerpt IDU',
+                (item) => (item.includeIdu ? 'yes' : 'no'),
+            ),
+            createTextColumn<ReportFigureFields, string>(
+                'is_housing_destruction',
+                'Housing Destruction',
+                (item) => (item.isHousingDestruction ? 'yes' : 'no'),
             ),
             createLinkColumn<ReportFigureFields, string>(
                 'event__name',

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -69,6 +69,7 @@ const GET_REPORT_FIGURES = gql`
                     includeIdu
                     isHousingDestruction
                     geolocations
+                    sourcesReliability
                     entry {
                         id
                         oldId
@@ -275,6 +276,12 @@ function ReportFigureTable(props: ReportFigureProps) {
                 'geolocations',
                 'Location',
                 (item) => item.geolocations,
+                { sortable: true },
+            ),
+            createTextColumn<ReportFigureFields, string>(
+                'sources_reliability',
+                'Sources Reliability',
+                (item) => item.sourcesReliability,
                 { sortable: true },
             ),
             createTextColumn<ReportFigureFields, string>(


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/188#issue-1344211753

## Depends on:
- Server branch: https://github.com/idmc-labs/helix-server/pull/336#issue-1377666049

## Changes:
- Add location, housing, idu and sources reliability columns for all the figure tables
- Also add logic to show only respective organizations of the chosen country

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
