### PR TITLE
Add triangle symbol based upon sources

### DIFF
--- a/src/Root/App/index.tsx
+++ b/src/Root/App/index.tsx
@@ -5,6 +5,7 @@ import { RetryLink } from 'apollo-link-retry';
 import { RestLink } from 'apollo-link-rest';
 import { BatchHttpLink } from 'apollo-link-batch-http';
 import { createUploadLink } from 'apollo-upload-client';
+import { isDefined } from '@togglecorp/fujs';
 
 import '@togglecorp/toggle-ui/build/index.css';
 import 'react-mde/lib/styles/css/react-mde-all.css';
@@ -17,7 +18,14 @@ const GRAPHQL_ENDPOINT = process.env.REACT_APP_GRAPHQL_ENDPOINT as string;
 
 const client = new ApolloClient({
     link: ApolloLink.from([
-        new RetryLink(),
+        new RetryLink({
+            attempts: {
+                max: 5,
+                retryIf: (error: { statusCode: number | undefined }) => (
+                    isDefined(error.statusCode) && error.statusCode < 400
+                ),
+            },
+        }),
         ApolloLink.split(
             (operation) => operation.getContext().hasUpload,
             createUploadLink({

--- a/src/components/tableHelpers/SymbolCell/index.tsx
+++ b/src/components/tableHelpers/SymbolCell/index.tsx
@@ -5,18 +5,27 @@ import {
 } from 'react-icons/io5';
 import styles from './styles.css';
 
+const low = 'Low';
+const high = 'High';
+const medium = 'Medium';
+const highToLow = 'High to Low';
+
 export interface SymbolCellProps {
     className?: string | null | undefined;
+    sourcesData?: string | null | undefined;
 }
 
 function SymbolCell(props: SymbolCellProps) {
     const {
         className,
+        sourcesData,
     } = props;
 
     return (
         <div className={_cs(styles.symbolDesign, className)}>
-            <IoTriangle />
+            {sourcesData === low && <IoTriangle style={{ color: 'green' }} />}
+            {(sourcesData === medium || sourcesData === highToLow) && <IoTriangle style={{ color: 'purple' }} />}
+            {sourcesData === high && <IoTriangle style={{ color: 'red' }} />}
         </div>
     );
 }

--- a/src/components/tableHelpers/SymbolCell/index.tsx
+++ b/src/components/tableHelpers/SymbolCell/index.tsx
@@ -3,16 +3,14 @@ import { _cs } from '@togglecorp/fujs';
 import {
     IoTriangle,
 } from 'react-icons/io5';
-import styles from './styles.css';
 
-const low = 'Low';
-const high = 'High';
-const medium = 'Medium';
-const highToLow = 'High to Low';
+import { Sources_Reliability as SourcesReliability } from '#generated/types';
+
+import styles from './styles.css';
 
 export interface SymbolCellProps {
     className?: string | null | undefined;
-    sourcesData?: string | null | undefined;
+    sourcesData?: SourcesReliability | null | undefined;
 }
 
 function SymbolCell(props: SymbolCellProps) {
@@ -23,9 +21,24 @@ function SymbolCell(props: SymbolCellProps) {
 
     return (
         <div className={_cs(styles.symbolDesign, className)}>
-            {sourcesData === low && <IoTriangle style={{ color: 'var(--color-danger)' }} />}
-            {(sourcesData === medium || sourcesData === highToLow) && <IoTriangle style={{ color: 'var(--color-warning)' }} />}
-            {sourcesData === high && <IoTriangle style={{ color: 'var(--color-success' }} />}
+            {(sourcesData === 'LOW' || sourcesData === 'LOW_TO_MEDIUM') && (
+                <IoTriangle
+                    title={sourcesData}
+                    style={{ color: 'var(--color-danger)' }}
+                />
+            )}
+            {(sourcesData === 'MEDIUM' || sourcesData === 'MEDIUM_TO_HIGH' || sourcesData === 'LOW_TO_HIGH') && (
+                <IoTriangle
+                    title={sourcesData}
+                    style={{ color: 'var(--color-warning)' }}
+                />
+            )}
+            {sourcesData === 'HIGH' && (
+                <IoTriangle
+                    title={sourcesData}
+                    style={{ color: 'var(--color-success' }}
+                />
+            )}
         </div>
     );
 }

--- a/src/components/tableHelpers/SymbolCell/index.tsx
+++ b/src/components/tableHelpers/SymbolCell/index.tsx
@@ -23,9 +23,9 @@ function SymbolCell(props: SymbolCellProps) {
 
     return (
         <div className={_cs(styles.symbolDesign, className)}>
-            {sourcesData === low && <IoTriangle style={{ color: 'green' }} />}
-            {(sourcesData === medium || sourcesData === highToLow) && <IoTriangle style={{ color: 'purple' }} />}
-            {sourcesData === high && <IoTriangle style={{ color: 'red' }} />}
+            {sourcesData === low && <IoTriangle style={{ color: 'var(--color-danger)' }} />}
+            {(sourcesData === medium || sourcesData === highToLow) && <IoTriangle style={{ color: 'var(--color-warning)' }} />}
+            {sourcesData === high && <IoTriangle style={{ color: 'var(--color-success' }} />}
         </div>
     );
 }

--- a/src/components/tableHelpers/SymbolCell/index.tsx
+++ b/src/components/tableHelpers/SymbolCell/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { _cs } from '@togglecorp/fujs';
+import {
+    IoTriangle,
+} from 'react-icons/io5';
+import styles from './styles.css';
+
+export interface SymbolCellProps {
+    className?: string | null | undefined;
+}
+
+function SymbolCell(props: SymbolCellProps) {
+    const {
+        className,
+    } = props;
+
+    return (
+        <div className={_cs(styles.symbolDesign, className)}>
+            <IoTriangle />
+        </div>
+    );
+}
+export default SymbolCell;

--- a/src/components/tableHelpers/SymbolCell/styles.css
+++ b/src/components/tableHelpers/SymbolCell/styles.css
@@ -1,3 +1,3 @@
 .symbol-design {
-    background-color: #ffffff;
+    padding-left: 1rem;
 }

--- a/src/components/tableHelpers/SymbolCell/styles.css
+++ b/src/components/tableHelpers/SymbolCell/styles.css
@@ -1,0 +1,3 @@
+.symbol-design {
+    background-color: #ffffff;
+}

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -24,6 +24,7 @@ import {
 import Message from '#components/Message';
 import Loading from '#components/Loading';
 import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
+import SymbolCell, { SymbolCellProps } from '#components/tableHelpers/SymbolCell';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
 
@@ -236,6 +237,23 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                 }),
             };
 
+            // eslint-disable-next-line max-len
+            const symbolColumn: TableColumn<FigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
+                id: 'sourceReliability',
+                title: 'Sources Reliability',
+                headerCellRenderer: TableHeaderCell,
+                headerCellRendererParams: {
+                    sortable: true,
+                },
+                cellRenderer: SymbolCell,
+                cellRendererParams: (_, datum) => ({
+                    signedOff: datum.reviewCount?.signedOffCount,
+                    reviewCompleted: datum.reviewCount?.reviewCompleteCount,
+                    underReview: datum.reviewCount?.underReviewCount,
+                    toBeReviewed: datum.reviewCount?.toBeReviewedCount,
+                }),
+            };
+
             return [
                 createDateColumn<FigureFields, string>(
                     'created_at',
@@ -325,6 +343,7 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     route.entryView,
                     { sortable: true },
                 ),
+                symbolColumn,
                 createNumberColumn<FigureFields, string>(
                     'total_figures',
                     'Total Figure',
@@ -404,7 +423,9 @@ function NudeFigureTable(props: NudeFigureTableProps) {
         },
         [
             handleFigureDelete,
-            crisisColumnHidden, eventColumnHidden, entryColumnHidden,
+            crisisColumnHidden,
+            eventColumnHidden,
+            entryColumnHidden,
             entryPermissions?.delete,
         ],
     );

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -239,7 +239,7 @@ function NudeFigureTable(props: NudeFigureTableProps) {
 
             // eslint-disable-next-line max-len
             const symbolColumn: TableColumn<FigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
-                id: 'sourceReliability',
+                id: 'sources_reliability',
                 title: 'Sources Reliability',
                 headerCellRenderer: TableHeaderCell,
                 headerCellRendererParams: {
@@ -368,12 +368,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                 createTextColumn<FigureFields, string>(
                     'include_idu',
                     'Excerpt IDU',
-                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                    (item) => (item.includeIdu ? 'Yes' : 'No'),
                 ),
                 createTextColumn<FigureFields, string>(
                     'is_housing_destruction',
                     'Housing Destruction',
-                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
+                    (item) => (item.isHousingDestruction ? 'Yes' : 'No'),
                 ),
                 createTextColumn<FigureFields, string>(
                     'figure_typology',

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -247,10 +247,7 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                 },
                 cellRenderer: SymbolCell,
                 cellRendererParams: (_, datum) => ({
-                    signedOff: datum.reviewCount?.signedOffCount,
-                    reviewCompleted: datum.reviewCount?.reviewCompleteCount,
-                    underReview: datum.reviewCount?.underReviewCount,
-                    toBeReviewed: datum.reviewCount?.toBeReviewedCount,
+                    sourcesData: datum?.sourcesReliability,
                 }),
             };
 

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -291,12 +291,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createTextColumn<FigureFields, string>(
-                    'sources_reliability',
-                    'Sources Reliability',
-                    (item) => item.sourcesReliability,
-                    { sortable: true },
-                ),
-                createTextColumn<FigureFields, string>(
                     'event__event_type',
                     'Cause',
                     (item) => item.event?.eventTypeDisplay,

--- a/src/views/Entry/EntryForm/FigureInput/index.tsx
+++ b/src/views/Entry/EntryForm/FigureInput/index.tsx
@@ -339,8 +339,6 @@ function FigureInput(props: FigureInputProps) {
         otherSubTypeOptions,
     } = props;
 
-    console.log('Organization List::>>>', organizations);
-
     const { notify } = useContext(NotificationContext);
     const { user } = useContext(DomainContext);
 

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -26,7 +26,6 @@ import Loading from '#components/Loading';
 import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
-
 import {
     ExtractionFigureListQuery,
     ExtractionFigureListQueryVariables,
@@ -250,6 +249,20 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     editLinkAttrs: { entryId: datum.entry.id },
                     editHash: '/figures-and-analysis',
                     editSearch: `id=${datum.id}`,
+                }),
+            };
+
+            // eslint-disable-next-line max-len
+            const symbolColumn: TableColumn<FigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
+                id: 'sourceReliability',
+                title: 'Sources Reliability',
+                headerCellRenderer: TableHeaderCell,
+                headerCellRendererParams: {
+                    sortable: true,
+                },
+                cellRenderer: SymbolCell,
+                cellRendererParams: (_, datum) => ({
+                    sourcesData: datum?.sourcesReliability,
                 }),
             };
 

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -255,7 +255,7 @@ function NudeFigureTable(props: NudeFigureTableProps) {
 
             // eslint-disable-next-line max-len
             const symbolColumn: TableColumn<FigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
-                id: 'sourceReliability',
+                id: 'sources_reliability',
                 title: 'Sources Reliability',
                 headerCellRenderer: TableHeaderCell,
                 headerCellRendererParams: {
@@ -382,12 +382,12 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                 createTextColumn<FigureFields, string>(
                     'include_idu',
                     'Excerpt IDU',
-                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                    (item) => (item.includeIdu ? 'Yes' : 'No'),
                 ),
                 createTextColumn<FigureFields, string>(
                     'is_housing_destruction',
                     'Housing Destruction',
-                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
+                    (item) => (item.isHousingDestruction ? 'Yes' : 'No'),
                 ),
                 createLinkColumn<FigureFields, string>(
                     'event__name',

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -26,6 +26,7 @@ import Loading from '#components/Loading';
 import ActionCell, { ActionProps } from '#components/tableHelpers/Action';
 import DomainContext from '#components/DomainContext';
 import NotificationContext from '#components/NotificationContext';
+import SymbolCell, { SymbolCellProps } from '#components/tableHelpers/SymbolCell';
 import {
     ExtractionFigureListQuery,
     ExtractionFigureListQueryVariables,
@@ -304,12 +305,6 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     { sortable: true },
                 ),
                 createTextColumn<FigureFields, string>(
-                    'sources_reliability',
-                    'Sources Reliability',
-                    (item) => item.sourcesReliability,
-                    { sortable: true },
-                ),
-                createTextColumn<FigureFields, string>(
                     'event__event_type',
                     'Cause',
                     (item) => item.event?.eventTypeDisplay,
@@ -353,6 +348,7 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     route.entryView,
                     { sortable: true },
                 ),
+                symbolColumn,
                 createNumberColumn<FigureFields, string>(
                     'total_figures',
                     'Total Figure',

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useMemo, useContext, useCallback } from 'react';
 import { gql, useQuery, useMutation } from '@apollo/client';
-import { _cs } from '@togglecorp/fujs';
+import { _cs, isDefined } from '@togglecorp/fujs';
 import {
     Table,
+    TableHeaderCell,
+    TableHeaderCellProps,
+    TableColumn,
     useSortState,
     Pager,
     SortContext,
@@ -25,7 +28,7 @@ import useDebouncedValue from '#hooks/useDebouncedValue';
 import Message from '#components/Message';
 import Container from '#components/Container';
 import Loading from '#components/Loading';
-
+import SymbolCell, { SymbolCellProps } from '#components/tableHelpers/SymbolCell';
 import {
     ReportFiguresListQuery,
     ReportFiguresListQueryVariables,
@@ -231,158 +234,167 @@ function ReportFigureTable(props: ReportFigureProps) {
     const totalReportFiguresCount = reportFigures?.report?.figuresReport?.totalCount ?? 0;
 
     const reportFigureColumns = useMemo(
-        () => ([
-            createDateColumn<ReportFigureFields, string>(
-                'created_at',
-                'Date Created',
-                (item) => item.createdAt,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'created_by__full_name',
-                'Created by',
-                (item) => item.createdBy?.fullName,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'entry__event__event_type',
-                'Cause',
-                (item) => item.event?.eventTypeDisplay,
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'figure_typology',
-                'Figure Type',
-                (item) => item.figureTypology,
-            ),
-            createStatusColumn<ReportFigureFields, string>(
-                'entry__article_title',
-                'Entry',
-                (item) => ({
-                    title: item.entry.articleTitle,
-                    attrs: { entryId: item.entry.id },
-                    isReviewed: item.entry.isReviewed,
-                    isSignedOff: item.entry.isSignedOff,
-                    isUnderReview: item.entry.isUnderReview,
-                    ext: item.entry.oldId
-                        ? `/documents/${item.entry.oldId}`
-                        : undefined,
-                    hash: '/figures-and-analysis',
-                    search: `id=${item.id}`,
+        () => {
+            // eslint-disable-next-line max-len
+            const symbolColumn: TableColumn<ReportFigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
+                id: 'sourceReliability',
+                title: 'Sources Reliability',
+                headerCellRenderer: TableHeaderCell,
+                headerCellRendererParams: {
+                    sortable: true,
+                },
+                cellRenderer: SymbolCell,
+                cellRendererParams: (_, datum) => ({
+                    sourcesData: datum?.sourcesReliability,
                 }),
-                route.entryView,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'geolocations',
-                'Location',
-                (item) => item.geolocations,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'sources_reliability',
-                'Sources Reliability',
-                (item) => item.sourcesReliability,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'country__idmc_short_name',
-                'Country',
-                (item) => item.country?.idmcShortName,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'term',
-                'Term',
-                (item) => item.termDisplay,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'role',
-                'Role',
-                (item) => item.roleDisplay,
-                { sortable: true },
-            ),
-            createLinkColumn<ReportFigureFields, string>(
-                'category',
-                'Figure Category',
-                (item) => ({
-                    title: item.categoryDisplay,
-                    attrs: { entryId: item.entry.id },
-                    ext: item.oldId
-                        ? `/facts/${item.oldId}`
-                        : undefined,
-                    hash: '/figures-and-analysis',
-                    search: `id=${item.id}`,
-                }),
-                route.entryView,
-                { sortable: true },
-            ),
-            createNumberColumn<ReportFigureFields, string>(
-                'total_figures',
-                'Total Figure',
-                (item) => item.totalFigures,
-                { sortable: true },
-            ),
-            createDateColumn<ReportFigureFields, string>(
-                'flow_start_date',
-                'Start Date',
-                (item) => item.flowStartDate,
-                { sortable: true },
-            ),
-            createDateColumn<ReportFigureFields, string>(
-                'flow_end_date',
-                'End Date',
-                (item) => item.flowEndDate,
-                { sortable: true },
-            ),
-            createDateColumn<ReportFigureFields, string>(
-                'stock_date',
-                'Stock Date',
-                (item) => item.stockDate,
-                { sortable: true },
-            ),
-            createDateColumn<ReportFigureFields, string>(
-                'stock_reporting_date',
-                'Stock Reporting Date',
-                (item) => item.stockReportingDate,
-                { sortable: true },
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'include_idu',
-                'Excerpt IDU',
-                (item) => (item.includeIdu ? 'yes' : 'no'),
-            ),
-            createTextColumn<ReportFigureFields, string>(
-                'is_housing_destruction',
-                'Housing Destruction',
-                (item) => (item.isHousingDestruction ? 'yes' : 'no'),
-            ),
-            createLinkColumn<ReportFigureFields, string>(
-                'event__name',
-                'Event',
-                (item) => ({
-                    title: item.event?.name,
-                    attrs: { eventId: item.event?.id },
-                    ext: item.event?.oldId
-                        ? `/events/${item.event.oldId}`
-                        : undefined,
-                }),
-                route.event,
-                { sortable: true },
-            ),
-            createLinkColumn<ReportFigureFields, string>(
-                'event__crisis__name',
-                'Crisis',
-                (item) => ({
-                    title: item.event?.crisis?.name,
-                    attrs: { crisisId: item.event?.crisis?.id },
-                    ext: undefined,
-                }),
-                route.crisis,
-                { sortable: true },
-            ),
-        ]),
-        [],
+            };
+            return [
+                createDateColumn<ReportFigureFields, string>(
+                    'created_at',
+                    'Date Created',
+                    (item) => item.createdAt,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'created_by__full_name',
+                    'Created by',
+                    (item) => item.createdBy?.fullName,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'entry__event__event_type',
+                    'Cause',
+                    (item) => item.event?.eventTypeDisplay,
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'figure_typology',
+                    'Figure Type',
+                    (item) => item.figureTypology,
+                ),
+                createStatusColumn<ReportFigureFields, string>(
+                    'entry__article_title',
+                    'Entry',
+                    (item) => ({
+                        title: item.entry.articleTitle,
+                        attrs: { entryId: item.entry.id },
+                        isReviewed: item.entry.isReviewed,
+                        isSignedOff: item.entry.isSignedOff,
+                        isUnderReview: item.entry.isUnderReview,
+                        ext: item.entry.oldId
+                            ? `/documents/${item.entry.oldId}`
+                            : undefined,
+                        hash: '/figures-and-analysis',
+                        search: `id=${item.id}`,
+                    }),
+                    route.entryView,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'geolocations',
+                    'Location',
+                    (item) => item.geolocations,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'country__idmc_short_name',
+                    'Country',
+                    (item) => item.country?.idmcShortName,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'term',
+                    'Term',
+                    (item) => item.termDisplay,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'role',
+                    'Role',
+                    (item) => item.roleDisplay,
+                    { sortable: true },
+                ),
+                createLinkColumn<ReportFigureFields, string>(
+                    'category',
+                    'Figure Category',
+                    (item) => ({
+                        title: item.categoryDisplay,
+                        attrs: { entryId: item.entry.id },
+                        ext: item.oldId
+                            ? `/facts/${item.oldId}`
+                            : undefined,
+                        hash: '/figures-and-analysis',
+                        search: `id=${item.id}`,
+                    }),
+                    route.entryView,
+                    { sortable: true },
+                ),
+                symbolColumn,
+                createNumberColumn<ReportFigureFields, string>(
+                    'total_figures',
+                    'Total Figure',
+                    (item) => item.totalFigures,
+                    { sortable: true },
+                ),
+                createDateColumn<ReportFigureFields, string>(
+                    'flow_start_date',
+                    'Start Date',
+                    (item) => item.flowStartDate,
+                    { sortable: true },
+                ),
+                createDateColumn<ReportFigureFields, string>(
+                    'flow_end_date',
+                    'End Date',
+                    (item) => item.flowEndDate,
+                    { sortable: true },
+                ),
+                createDateColumn<ReportFigureFields, string>(
+                    'stock_date',
+                    'Stock Date',
+                    (item) => item.stockDate,
+                    { sortable: true },
+                ),
+                createDateColumn<ReportFigureFields, string>(
+                    'stock_reporting_date',
+                    'Stock Reporting Date',
+                    (item) => item.stockReportingDate,
+                    { sortable: true },
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'include_idu',
+                    'Excerpt IDU',
+                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                ),
+                createTextColumn<ReportFigureFields, string>(
+                    'is_housing_destruction',
+                    'Housing Destruction',
+                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
+                ),
+                createLinkColumn<ReportFigureFields, string>(
+                    'event__name',
+                    'Event',
+                    (item) => ({
+                        title: item.event?.name,
+                        attrs: { eventId: item.event?.id },
+                        ext: item.event?.oldId
+                            ? `/events/${item.event.oldId}`
+                            : undefined,
+                    }),
+                    route.event,
+                    { sortable: true },
+                ),
+                createLinkColumn<ReportFigureFields, string>(
+                    'event__crisis__name',
+                    'Crisis',
+                    (item) => ({
+                        title: item.event?.crisis?.name,
+                        attrs: { crisisId: item.event?.crisis?.id },
+                        ext: undefined,
+                    }),
+                    route.crisis,
+                    { sortable: true },
+                ),
+            ].filter(isDefined);
+        }, [],
     );
 
     return (

--- a/src/views/Report/ReportFigureTable/index.tsx
+++ b/src/views/Report/ReportFigureTable/index.tsx
@@ -237,7 +237,7 @@ function ReportFigureTable(props: ReportFigureProps) {
         () => {
             // eslint-disable-next-line max-len
             const symbolColumn: TableColumn<ReportFigureFields, string, SymbolCellProps, TableHeaderCellProps> = {
-                id: 'sourceReliability',
+                id: 'sources_reliability',
                 title: 'Sources Reliability',
                 headerCellRenderer: TableHeaderCell,
                 headerCellRendererParams: {
@@ -362,12 +362,12 @@ function ReportFigureTable(props: ReportFigureProps) {
                 createTextColumn<ReportFigureFields, string>(
                     'include_idu',
                     'Excerpt IDU',
-                    (item) => (item.includeIdu ? 'yes' : 'no'),
+                    (item) => (item.includeIdu ? 'Yes' : 'No'),
                 ),
                 createTextColumn<ReportFigureFields, string>(
                     'is_housing_destruction',
                     'Housing Destruction',
-                    (item) => (item.isHousingDestruction ? 'yes' : 'no'),
+                    (item) => (item.isHousingDestruction ? 'Yes' : 'No'),
                 ),
                 createLinkColumn<ReportFigureFields, string>(
                     'event__name',


### PR DESCRIPTION
Depends on https://github.com/idmc-labs/helix-server/pull/339

## Addresses:
- Triangle symbol for "Sources and reliability" column for all figures

## Changes
- Add a column in all figure tables that showcases a 'triangle' symbol
- Color of the triangle is based upon the sources and reliability data

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
