### PR TITLE
Display reviews on "Entry Edit" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
         "@togglecorp/fujs": "^1.9.2-beta.0",
         "@togglecorp/re-map": "^0.1.3",
         "@togglecorp/toggle-form": "^0.2.0-beta.6",
-        "@togglecorp/toggle-ui": "^0.16.0-beta.2",
+        "@togglecorp/toggle-ui": "^0.16.0-beta.3",
         "@turf/bbox": "^6.0.1",
         "@turf/bbox-polygon": "^6.0.1",
         "@turf/combine": "^6.0.1",

--- a/src/components/TrafficLightInput/ReviewComments/CommentForm/index.tsx
+++ b/src/components/TrafficLightInput/ReviewComments/CommentForm/index.tsx
@@ -11,7 +11,6 @@ import {
     ObjectSchema,
     createSubmitHandler,
     removeNull,
-    requiredStringCondition,
     idCondition,
 } from '@togglecorp/toggle-form';
 import { gql, useMutation, useQuery } from '@apollo/client';
@@ -129,7 +128,7 @@ type FormSchemaFields = ReturnType<FormSchema['fields']>;
 const schema: FormSchema = {
     fields: (): FormSchemaFields => ({
         id: [idCondition],
-        comment: [requiredStringCondition],
+        comment: [],
         commentType: [],
     }),
 };
@@ -368,7 +367,7 @@ function CommentForm(props: CommentFormProps) {
                     name={undefined}
                     variant="primary"
                     type="submit"
-                    disabled={pristine || loading || !value.comment}
+                    disabled={pristine || loading || (value.commentType !== 'GREEN' && !value.comment)}
                 >
                     Submit
                 </Button>

--- a/src/components/forms/EntryForm/FigureInput/index.tsx
+++ b/src/components/forms/EntryForm/FigureInput/index.tsx
@@ -16,6 +16,7 @@ import {
     Switch,
     SelectInput,
     Button,
+    ConfirmButton,
     Modal,
 } from '@togglecorp/toggle-ui';
 import {
@@ -347,9 +348,8 @@ interface FigureInputProps {
     osvSubTypeOptions: OsvSubTypeOptions | null | undefined,
     onFigureClone?: (item: FigureInputValue) => void;
 
-    reviewStatus?: FigureReviewStatus;
     entryId?: string;
-
+    reviewStatus?: FigureReviewStatus | null | undefined;
     fieldStatuses?: FigureLastReviewCommentStatusType[] | null | undefined;
 }
 
@@ -1116,33 +1116,34 @@ function FigureInput(props: FigureInputProps) {
                     >
                         Clone
                     </Button>
-                    <Button
+                    <ConfirmButton
                         name={index}
-                        onClick={handleClearForm}
+                        onConfirm={handleClearForm}
                         disabled={disabled}
                     >
                         Clear
-                    </Button>
-                    <Button
+                    </ConfirmButton>
+                    <ConfirmButton
                         name={index}
-                        onClick={onRemove}
+                        onConfirm={onRemove}
                         disabled={disabled}
                     >
                         Remove
-                    </Button>
+                    </ConfirmButton>
                 </>
             )}
             {figureId && reviewMode && (
                 <>
-                    {/* FIXME: only show this if not in entry page */}
-                    <ButtonLikeLink
-                        route={route.entryEdit}
-                        attrs={{ entryId }}
-                        hash="/figures-and-analysis"
-                        search={`id=${figureId}`}
-                    >
-                        Edit
-                    </ButtonLikeLink>
+                    {entryId && (
+                        <ButtonLikeLink
+                            route={route.entryEdit}
+                            attrs={{ entryId }}
+                            hash="/figures-and-analysis"
+                            search={`id=${figureId}`}
+                        >
+                            Edit
+                        </ButtonLikeLink>
+                    )}
                     {isUserAssignee && figurePermission?.approve && (
                         reviewStatus === 'APPROVED' ? (
                             <Button

--- a/src/components/forms/EntryForm/index.tsx
+++ b/src/components/forms/EntryForm/index.tsx
@@ -5,6 +5,7 @@ import {
     _cs,
     unique,
     isDefined,
+    listToMap,
 } from '@togglecorp/fujs';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -399,6 +400,8 @@ function EntryForm(props: EntryFormProps) {
     const {
         loading: getEntryLoading,
         error: entryDataError,
+        previousData: previousEntryData,
+        data: entryData = previousEntryData,
     } = useQuery<EntryQuery, EntryQueryVariables>(ENTRY, {
         skip: !variables,
         variables,
@@ -489,6 +492,22 @@ function EntryForm(props: EntryFormProps) {
             }
         },
     });
+
+    const figureMapping = useMemo(
+        () => {
+            const figures = entryData?.entry?.figures;
+            const mapping = listToMap(
+                figures,
+                (figure) => figure.uuid,
+                (figure) => ({
+                    reviewStatus: figure.reviewStatus,
+                    fieldStatuses: figure.lastReviewCommentStatus,
+                }),
+            );
+            return mapping;
+        },
+        [entryData],
+    );
 
     // eslint-disable-next-line max-len
     const loading = getEntryLoading || saveLoading || updateLoading || createAttachmentLoading || parkedItemDataLoading || createSourcePreviewLoading;
@@ -868,6 +887,8 @@ function EntryForm(props: EntryFormProps) {
                                     organizations={organizations}
                                     setOrganizations={setOrganizations}
                                     onFigureClone={handleFigureClone}
+                                    reviewStatus={figureMapping[fig.uuid]?.reviewStatus}
+                                    fieldStatuses={figureMapping[fig.uuid]?.fieldStatuses}
                                 />
                             ))}
                         </Section>

--- a/src/components/forms/EntryForm/queries.tsx
+++ b/src/components/forms/EntryForm/queries.tsx
@@ -174,63 +174,67 @@ export const FIGURE_FRAGMENT = gql`
     }
 `;
 
-export const ENTRY = gql`
+export const ENTRY_FRAGMENT = gql`
     ${FIGURE_FRAGMENT}
-    query Entry($id: ID!) {
-        entry(id: $id) {
-            associatedParkedItem {
-                id
-            }
-            figures {
-                ...FigureResponse
-            }
-            articleTitle
-            document {
-                id
-                attachment
-            }
-            documentUrl
+    fragment EntryResponse on EntryType {
+        associatedParkedItem {
             id
-            idmcAnalysis
-            isConfidential
-            preview {
-                status
+        }
+        figures {
+            ...FigureResponse
+        }
+        articleTitle
+        document {
+            id
+            attachment
+        }
+        documentUrl
+        id
+        idmcAnalysis
+        isConfidential
+        preview {
+            status
+            id
+            pdf
+            remark
+            url
+        }
+        publishDate
+        publishers {
+            results {
                 id
-                pdf
-                remark
-                url
-            }
-            publishDate
-            publishers {
-                results {
+                name
+                methodology
+                countries {
+                    id
+                    idmcShortName
+                }
+                organizationKind {
                     id
                     name
-                    methodology
-                    countries {
-                        id
-                        idmcShortName
-                    }
-                    organizationKind {
-                        id
-                        name
-                        reliability
-                    }
+                    reliability
                 }
             }
-            url
+        }
+        url
+    }
+`;
+
+export const ENTRY = gql`
+    ${ENTRY_FRAGMENT}
+    query Entry($id: ID!) {
+        entry(id: $id) {
+            ...EntryResponse
         }
     }
 `;
 
 export const CREATE_ENTRY = gql`
-    ${FIGURE_FRAGMENT}
+    ${ENTRY_FRAGMENT}
     mutation CreateEntry($entry: EntryCreateInputType!) {
         createEntry(data: $entry) {
             result {
-                id
-                figures {
-                    ...FigureResponse
-                }
+                ...EntryResponse
             }
             errors
         }
@@ -242,10 +246,7 @@ export const UPDATE_ENTRY = gql`
     mutation UpdateEntry($entry: EntryUpdateInputType!) {
         updateEntry(data: $entry) {
             result {
-                id
-                figures {
-                    ...FigureResponse
-                }
+                ...EntryResponse
             }
             errors
         }

--- a/src/views/Entry/index.tsx
+++ b/src/views/Entry/index.tsx
@@ -63,8 +63,7 @@ function Entry(props: EntryProps) {
         },
         [],
     );
-    // NOTE: show traffic light by default only on view mode
-    const [trafficLightShown, setTrafficLightShown] = useState(mode === 'view');
+    const [trafficLightShown, setTrafficLightShown] = useState(true);
 
     let title: string;
     let link: React.ReactNode | undefined;

--- a/src/views/EventReview/index.tsx
+++ b/src/views/EventReview/index.tsx
@@ -100,6 +100,11 @@ function transform(figures: NonNullable<FigureListQuery['figureList']>['results'
     })) ?? [];
     return removeNull(transformedFigures);
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noOp() {
+}
+
 interface Props {
     className: string;
 }
@@ -338,8 +343,8 @@ function EventReview(props: Props) {
                             setSelectedFigure={setSelectedFigure}
                             index={index}
                             value={fig}
-                            onChange={() => null}
-                            onRemove={() => null}
+                            onChange={noOp}
+                            onRemove={noOp}
                             error={undefined}
                             disabled={getFiguresLoading}
                             mode={mode}
@@ -381,8 +386,8 @@ function EventReview(props: Props) {
                             trafficLightShown={trafficLightShown}
                             organizations={organizations}
                             setOrganizations={setOrganizations}
-                            reviewStatus={fig.reviewStatus}
                             entryId={fig.entry.id}
+                            reviewStatus={fig.reviewStatus}
                             fieldStatuses={fig.lastReviewCommentStatus}
                         />
                     ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3828,10 +3828,10 @@
     "@storybook/client-api" "^6.0.21"
     "@togglecorp/fujs" "^1.9.2-beta.0"
 
-"@togglecorp/toggle-ui@^0.16.0-beta.2":
-  version "0.16.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.16.0-beta.2.tgz#9f8067db801ae503333683b932b3ddf65ab052f7"
-  integrity sha512-oKzD5+eMFG4az1yixEEgWzDC+1bhrGMOnSGoO+AcUAovT3LgH+jw6qt65z16iQMcchWHTWLBSgDifkeQO51Ykg==
+"@togglecorp/toggle-ui@^0.16.0-beta.3":
+  version "0.16.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-ui/-/toggle-ui-0.16.0-beta.3.tgz#522c8a7a1073f924e65ca02470122f96004cdc58"
+  integrity sha512-Gx3wdKh92fj7FOMI06yb+U47cC7kCzxIvTh4bMTGyb3gTTjUBrOe7YlhHDV3gAVCYc7JdIzKlNMWpUjuqn5lSA==
   dependencies:
     "@babel/runtime-corejs3" "^7.11.2"
     "@tanem/svg-injector" "^10.1.12"


### PR DESCRIPTION
Depends on https://github.com/idmc-labs/helix-server/pull/392

- Show traffic lights by default
- Use confirmation button for Clear and Remove button on Figure
- Hide "Edit Figure" link on "Entry Edit" page
- Make "comment" non-mandatory for "GREEN" review type

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
