### PR TITLE
Add fixes for all sticky action columns 

### DIFF
--- a/src/components/QuickActionButton/styles.css
+++ b/src/components/QuickActionButton/styles.css
@@ -1,5 +1,7 @@
 .button {
     --padding: var(--spacing-small);
+    width: 26px;
+    height: 26px;
     font-size: var(--font-size-medium);
 
     &.round-button {

--- a/src/components/QuickActionConfirmButton/styles.css
+++ b/src/components/QuickActionConfirmButton/styles.css
@@ -1,5 +1,7 @@
 .button {
     --padding: var(--spacing-small);
+    width: 26px;
+    height: 26px;
     font-size: var(--font-size-medium);
 
     &.round-button {

--- a/src/components/QuickActionLink/styles.css
+++ b/src/components/QuickActionLink/styles.css
@@ -1,8 +1,11 @@
 .quick-action-link{
     --padding: var(--spacing-small);
-
     border-radius: calc(1em + var(--padding) / 2);
     padding: var(--padding);
+
+    width: 26px;
+    height: 26px;
+
     font-size: var(--font-size-medium);
 
     .children {

--- a/src/components/tableHelpers/index.tsx
+++ b/src/components/tableHelpers/index.tsx
@@ -43,7 +43,7 @@ export function getWidthFromN(n: number) {
     if (n === 0) {
         return 0;
     }
-    const buttonSize = 34;
+    const buttonSize = 26;
     const gapSize = 6;
     const padding = 10;
     const extra = 1; // border takes one extra pixel right now

--- a/src/components/tableHelpers/index.tsx
+++ b/src/components/tableHelpers/index.tsx
@@ -39,6 +39,17 @@ export function getWidthFromSize(size: Size | undefined) {
     }
 }
 
+export function getWidthFromN(n: number) {
+    if (n === 0) {
+        return 0;
+    }
+    const buttonSize = 34;
+    const gapSize = 6;
+    const padding = 10;
+    const extra = 1; // border takes one extra pixel right now
+    return buttonSize * n + gapSize * (n - 1) + 2 * padding + extra;
+}
+
 export interface ColumnOptions {
     sortable?: boolean,
     defaultSortDirection?: TableSortDirection,
@@ -230,13 +241,12 @@ export function createActionColumn<D, K>(
         onDelete: ((id: string) => void) | undefined,
     },
     options?: ColumnOptions,
-    size: Size = 'medium',
+    size: Size | number = 'medium',
 ) {
     const item: TableColumn<D, K, ActionProps, TableHeaderCellProps> = {
         id,
         title: title || 'Actions',
-        // FIXME: get this from expected number of icons
-        columnWidth: getWidthFromSize(size),
+        columnWidth: typeof size === 'number' ? getWidthFromN(size) : getWidthFromSize(size),
         headerCellRenderer: TableHeaderCell,
         headerCellRendererParams: {
             sortable: options?.sortable,
@@ -271,12 +281,12 @@ export function createCustomActionColumn<D, K, J>(
     id: string,
     title: string | undefined,
     options?: ColumnOptions,
-    size: Size = 'medium',
+    size: Size | number = 'medium',
 ) {
     const item: TableColumn<D, K, J, TableHeaderCellProps> = {
         id,
         title: title ?? 'Actions',
-        columnWidth: getWidthFromSize(size),
+        columnWidth: typeof size === 'number' ? getWidthFromN(size) : getWidthFromSize(size),
         headerCellRenderer: TableHeaderCell,
         headerCellRendererParams: {
             sortable: options?.sortable,

--- a/src/components/tableHelpers/styles.css
+++ b/src/components/tableHelpers/styles.css
@@ -16,16 +16,16 @@
 .action-cell, .action-cell-header {
     position: sticky;
     right: 0;
-    background-color: white;
+    background-color: var(--color-foreground);
 }
 
 .action-cell-header {
     position: sticky;
     right: 0;
 
-    border-left: 1px solid rgba(0, 0, 0, 0.1);
-    box-shadow: -3px 0 3px -1px rgba(0, 0, 0, 0.1);
-    background-color: white;
+    border-left: var(--width-separator-thin) solid var(--color-separator);
+    box-shadow: -3px 0 3px -1px rgba(0, 0, 0, 0.05);
+    background-color: var(--color-foreground);
 }
 
 .action-cell-item {

--- a/src/components/tables/ContactsTable/CommunicationTable/index.tsx
+++ b/src/components/tables/ContactsTable/CommunicationTable/index.tsx
@@ -257,6 +257,8 @@ function CommunicationTable(props: CommunicationListProps) {
                     onDelete: commPermissions?.delete ? handleCommunicationDelete : undefined,
                     onEdit: commPermissions?.change ? showAddCommunicationModal : undefined,
                 }),
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [

--- a/src/components/tables/ContactsTable/index.tsx
+++ b/src/components/tables/ContactsTable/index.tsx
@@ -378,6 +378,8 @@ function ContactsTable(props: ContactsTableProps) {
                     onDelete: contactPermissions?.delete ? handleContactDelete : undefined,
                     onEdit: contactPermissions?.change ? showAddContactModal : undefined,
                 }),
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [

--- a/src/components/tables/EntriesFiguresTable/NudeEntryTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeEntryTable/index.tsx
@@ -224,6 +224,8 @@ function NudeEntryTable(props: NudeEntryTableProps) {
                 }),
                 'action',
                 '',
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [

--- a/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/NudeFigureTable/index.tsx
@@ -402,6 +402,8 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     }),
                     'action',
                     '',
+                    undefined,
+                    2,
                 ),
             ].filter(isDefined);
         },

--- a/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/EventsAction/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/EventsAction/index.tsx
@@ -15,7 +15,6 @@ import QuickActionLink from '#components/QuickActionLink';
 import QuickActionConfirmButton from '#components/QuickActionConfirmButton';
 
 import { RouteData, Attrs } from '#hooks/useRouteMatching';
-import ButtonLikeLink from '#components/ButtonLikeLink';
 import route from '#config/routes';
 
 export interface ActionProps {
@@ -97,7 +96,7 @@ function EventActionCell(props: ActionProps) {
         <Actions className={className}>
             {children}
             {onReview && (
-                <ButtonLikeLink
+                <QuickActionLink
                     title="Review"
                     icons={<IoReaderOutline />}
                     route={route.eventReview}

--- a/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/index.tsx
@@ -532,6 +532,8 @@ function NudeEventTable(props: EventsProps) {
                 }),
                 'action',
                 '',
+                undefined,
+                1,
             );
 
             const actionColumn = createCustomActionColumn<EventFields, string, ActionProps>(
@@ -572,7 +574,7 @@ function NudeEventTable(props: EventsProps) {
                 'action',
                 '',
                 undefined,
-                'large',
+                7,
             );
 
             // eslint-disable-next-line max-len

--- a/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/NudeEventsTable/index.tsx
@@ -574,7 +574,7 @@ function NudeEventTable(props: EventsProps) {
                 'action',
                 '',
                 undefined,
-                7,
+                6,
             );
 
             // eslint-disable-next-line max-len

--- a/src/components/tables/ParkedItemTable/index.tsx
+++ b/src/components/tables/ParkedItemTable/index.tsx
@@ -311,7 +311,7 @@ function ParkedItemTable(props: ParkedItemProps) {
                 'action',
                 '',
                 undefined,
-                'medium-large',
+                3,
             ),
         ].filter(isDefined)),
         [

--- a/src/views/Actors/ActorTable/index.tsx
+++ b/src/views/Actors/ActorTable/index.tsx
@@ -316,6 +316,8 @@ function ActorTable(props: ActorProps) {
                     onEdit: actorPermissions?.change ? showAddActorModal : undefined,
                     onDelete: actorPermissions?.delete ? handleActorDelete : undefined,
                 }),
+                undefined,
+                2,
             ),
         ]),
         [

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -309,6 +309,8 @@ function UserRoles(props: UserRolesProps) {
                 }),
                 'action',
                 '',
+                undefined,
+                2,
             ),
         ]),
         [

--- a/src/views/ContextualUpdates/index.tsx
+++ b/src/views/ContextualUpdates/index.tsx
@@ -280,6 +280,8 @@ function ContextualUpdates(props: ContextualUpdatesProps) {
                         ? handleContextualUpdateDelete
                         : undefined,
                 }),
+                undefined,
+                1,
             ),
         ]),
         [

--- a/src/views/Crises/index.tsx
+++ b/src/views/Crises/index.tsx
@@ -415,6 +415,8 @@ function Crises(props: CrisesProps) {
                         onDelete: crisisPermissions?.delete ? handleCrisisDelete : undefined,
                         onEdit: crisisPermissions?.change ? showAddCrisisModal : undefined,
                     }),
+                    undefined,
+                    2,
                 ),
             ];
         },

--- a/src/views/Extraction/ExtractionEntriesTable/NudeEntryTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeEntryTable/index.tsx
@@ -241,6 +241,8 @@ function NudeEntryTable(props: NudeEntryTableProps) {
                 }),
                 'action',
                 '',
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [

--- a/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
+++ b/src/views/Extraction/ExtractionEntriesTable/NudeFigureTable/index.tsx
@@ -402,6 +402,8 @@ function NudeFigureTable(props: NudeFigureTableProps) {
                     }),
                     'action',
                     '',
+                    undefined,
+                    2,
                 ),
             ].filter(isDefined);
         },

--- a/src/views/FigureTags/FigureTagsTable/index.tsx
+++ b/src/views/FigureTags/FigureTagsTable/index.tsx
@@ -233,6 +233,8 @@ function FigureTagsTable(props: FigureTagsProps) {
                     onDelete: figureTagPermissions?.delete ? handleFigureTagDelete : undefined,
                     onEdit: figureTagPermissions?.change ? showAddFigureTagModal : undefined,
                 }),
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [

--- a/src/views/Notifications/index.tsx
+++ b/src/views/Notifications/index.tsx
@@ -395,7 +395,7 @@ function Notifications(props: NotificationsProps) {
                     'action',
                     'Action',
                     undefined,
-                    'small',
+                    1,
                 ),
             ];
         },

--- a/src/views/Organizations/OrganizationTable/index.tsx
+++ b/src/views/Organizations/OrganizationTable/index.tsx
@@ -343,6 +343,8 @@ function OrganizationTable(props: OrganizationProps) {
                     onEdit: orgPermissions?.change ? showAddOrganizationModal : undefined,
                     onDelete: orgPermissions?.delete ? handleOrganizationDelete : undefined,
                 }),
+                undefined,
+                2,
             ),
         ]),
         [

--- a/src/views/Reports/index.tsx
+++ b/src/views/Reports/index.tsx
@@ -391,6 +391,8 @@ function Reports(props: ReportsProps) {
                     onEdit: reportPermissions?.change ? showAddReportModal : undefined,
                     onDelete: reportPermissions?.delete ? handleReportDelete : undefined,
                 }),
+                undefined,
+                2,
             ),
         ]),
         [

--- a/src/views/ViolenceContext/ViolenceContextTable/index.tsx
+++ b/src/views/ViolenceContext/ViolenceContextTable/index.tsx
@@ -243,6 +243,8 @@ function ContextOfViolenceTable(props: ContextOfViolenceProps) {
                     onEdit: violenceContextPermissions
                         ?.change ? showViolenceContextModal : undefined,
                 }),
+                undefined,
+                2,
             ),
         ].filter(isDefined)),
         [


### PR DESCRIPTION
## Addresses:
- Adjust a specified width for all sticky columns

## Depends on:
- Server branch: https://github.com/idmc-labs/helix-server/pull/374#issue-1453018264 

## Changes:
- Add a logic to calculate generic sizes for all icons of sticky action columns

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
