### PR TITLE
Add a category heading for QA tab options

### DIFF
--- a/src/components/lists/MyResources/ResourcesAccordion/index.tsx
+++ b/src/components/lists/MyResources/ResourcesAccordion/index.tsx
@@ -74,6 +74,7 @@ function ResourcesAccordion(props: ResourcesAccordionProps) {
 
     return (
         <Accordion
+            groupClassName={styles.accordionGroup}
             data={myResourcesList}
             keySelector={getKeySelectorId}
             groupKeySelector={getGroupKeySelector}

--- a/src/components/lists/MyResources/ResourcesAccordion/styles.css
+++ b/src/components/lists/MyResources/ResourcesAccordion/styles.css
@@ -3,6 +3,8 @@
     font-weight: var(--font-weight-bold);
 }
 
-.item {
-    padding-left: var(--spacing-large);
+.accordion-group {
+    .item {
+        padding-left: var(--spacing-extra-large);
+    }
 }

--- a/src/views/QADashboard/index.tsx
+++ b/src/views/QADashboard/index.tsx
@@ -11,7 +11,7 @@ import Container from '#components/Container';
 import EventsTable from '#components/tables/EventsTable';
 import DomainContext from '#components/DomainContext';
 import PageHeader from '#components/PageHeader';
-import Header from '#components/Header';
+import Heading from '#components/Heading';
 import EntriesFiguresTable from '#components/tables/EntriesFiguresTable';
 
 import styles from './styles.css';
@@ -88,46 +88,47 @@ function QADashboard(props: QAProps) {
                         contentClassName={styles.sidePaneContent}
                         heading="Categories"
                     >
-                        <Header
-                            className={_cs(
-                                styles.categoryLabel,
-                            )}
-                            heading="Potential Errors"
+                        <Heading
                             size="small"
-                        />
-                        <TabRedux
-                            name="events-with-multiple-recommended-figures"
+                            className={styles.groupHeading}
                         >
-                            Events with multiple recommended figures
-                        </TabRedux>
-                        <TabRedux
-                            name="events-with-no-recommended-figures"
-                        >
-                            Events with no recommended figures
-                        </TabRedux>
-                        <br />
-                        <Header
-                            className={_cs(
-                                styles.categoryLabel,
-                            )}
-                            heading="QA Process"
+                            Potential Errors
+                        </Heading>
+                        <div className={styles.group}>
+                            <TabRedux
+                                name="events-with-multiple-recommended-figures"
+                            >
+                                Events with multiple recommended figures
+                            </TabRedux>
+                            <TabRedux
+                                name="events-with-no-recommended-figures"
+                            >
+                                Events with no recommended figures
+                            </TabRedux>
+                        </div>
+                        <Heading
                             size="small"
-                        />
-                        <TabRedux
-                            name="figures-with-review-requested"
+                            className={styles.groupHeading}
                         >
-                            Figures with review requested
-                        </TabRedux>
-                        <TabRedux
-                            name="assigned-events"
-                        >
-                            Assigned Events
-                        </TabRedux>
-                        <TabRedux
-                            name="ignored-events"
-                        >
-                            Ignored Events
-                        </TabRedux>
+                            QA Process
+                        </Heading>
+                        <div className={styles.group}>
+                            <TabRedux
+                                name="figures-with-review-requested"
+                            >
+                                Figures with review requested
+                            </TabRedux>
+                            <TabRedux
+                                name="assigned-events"
+                            >
+                                Assigned Events
+                            </TabRedux>
+                            <TabRedux
+                                name="ignored-events"
+                            >
+                                Ignored Events
+                            </TabRedux>
+                        </div>
                     </Container>
                 </div>
                 <div className={styles.mainContent}>

--- a/src/views/QADashboard/index.tsx
+++ b/src/views/QADashboard/index.tsx
@@ -11,6 +11,7 @@ import Container from '#components/Container';
 import EventsTable from '#components/tables/EventsTable';
 import DomainContext from '#components/DomainContext';
 import PageHeader from '#components/PageHeader';
+import Header from '#components/Header';
 import EntriesFiguresTable from '#components/tables/EntriesFiguresTable';
 
 import styles from './styles.css';
@@ -87,6 +88,13 @@ function QADashboard(props: QAProps) {
                         contentClassName={styles.sidePaneContent}
                         heading="Categories"
                     >
+                        <Header
+                            className={_cs(
+                                styles.categoryLabel,
+                            )}
+                            heading="Potential Errors"
+                            size="small"
+                        />
                         <TabRedux
                             name="events-with-multiple-recommended-figures"
                         >
@@ -97,6 +105,14 @@ function QADashboard(props: QAProps) {
                         >
                             Events with no recommended figures
                         </TabRedux>
+                        <br />
+                        <Header
+                            className={_cs(
+                                styles.categoryLabel,
+                            )}
+                            heading="QA Process"
+                            size="small"
+                        />
                         <TabRedux
                             name="figures-with-review-requested"
                         >

--- a/src/views/QADashboard/styles.css
+++ b/src/views/QADashboard/styles.css
@@ -32,6 +32,11 @@
                 position: relative;
                 flex-direction: column;
             }
+
+            .category-label {
+                color: var(--color-text-label);
+                font-size: var(--font-size--medium);
+            }
         }
     }
 }

--- a/src/views/QADashboard/styles.css
+++ b/src/views/QADashboard/styles.css
@@ -31,6 +31,16 @@
                 display: flex;
                 position: relative;
                 flex-direction: column;
+
+                .group-heading {
+                    padding: var(--spacing-small) 0;
+                }
+
+                .group {
+                    >* {
+                        padding-left: var(--spacing-extra-large);
+                    }
+                }
             }
 
             .category-label {


### PR DESCRIPTION
## Addresses:
- Issue:  https://github.com/idmc-labs/helix2.0-meta/issues/245#issue-1492194052

## Changes:
- Add a header for the list of tab options in the side bar section of QA page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
