### PR TITLE
Replace disaster types by hazard types

### DIFF
--- a/src/components/selections/EventListSelectInput/index.tsx
+++ b/src/components/selections/EventListSelectInput/index.tsx
@@ -110,7 +110,7 @@ function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
                     )}
                     {selectedEvent.eventType === 'DISASTER' && (
                         <TextInput
-                            label="Event Disaster Type"
+                            label="Event Hazard Type"
                             name="disasterSubType"
                             disabled={disabled}
                             readOnly

--- a/src/components/tables/EventsEntriesFiguresTable/EventsFilter/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/EventsFilter/index.tsx
@@ -410,7 +410,7 @@ function EventsFilter(props: EventsFilterProps) {
                         options={disasterSubTypeOptions}
                         keySelector={basicEntityKeySelector}
                         labelSelector={basicEntityLabelSelector}
-                        label="Disaster Types"
+                        label="Hazard Types"
                         name="disasterSubTypes"
                         value={value.disasterSubTypes}
                         onChange={onValueChange}

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -261,7 +261,7 @@ function Event(props: EventProps) {
                             {eventData?.event?.eventType === 'DISASTER' && (
                                 <>
                                     <TextBlock
-                                        label="Disaster Subtype"
+                                        label="Hazard Subtype"
                                         value={eventData?.event?.disasterSubType?.name}
                                     />
                                     <div />

--- a/src/views/Reports/ReportForm/index.tsx
+++ b/src/views/Reports/ReportForm/index.tsx
@@ -637,7 +637,7 @@ function ReportForm(props: ReportFormProps) {
                         options={disasterSubTypeOptions}
                         keySelector={basicEntityKeySelector}
                         labelSelector={basicEntityLabelSelector}
-                        label="Disaster Type"
+                        label="Hazard Types"
                         name="filterFigureDisasterSubTypes"
                         value={value.filterFigureDisasterSubTypes}
                         onChange={onValueChange}


### PR DESCRIPTION
## Addresses:
- https://github.com/idmc-labs/helix2.0-meta/issues/320#issue-1574990399

## Related:
- https://github.com/idmc-labs/helix-server/pull/438

## Changes:
- Replace "Disaster Types" by "Hazard Types"

## This PR doesn't introduce any:
- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:
- [ ] permission checks
- [ ] translations
