### PR TITLE
Add a modal to update the email of users in admin section

### DIFF
--- a/src/components/forms/UserEmailChangeForm/index.tsx
+++ b/src/components/forms/UserEmailChangeForm/index.tsx
@@ -1,0 +1,187 @@
+import React, { useContext } from 'react';
+import { _cs } from '@togglecorp/fujs';
+import { TextInput } from '@togglecorp/toggle-ui';
+import {
+    removeNull,
+    ObjectSchema,
+    useForm,
+    createSubmitHandler,
+    idCondition,
+    PartialForm,
+    PurgeNull,
+    emailCondition,
+} from '@togglecorp/toggle-form';
+
+import {
+    gql,
+    useMutation,
+} from '@apollo/client';
+
+import NotificationContext from '#components/NotificationContext';
+import Loading from '#components/Loading';
+import NonFieldError from '#components/NonFieldError';
+
+import {
+    WithId,
+} from '#utils/common';
+import { transformToFormError } from '#utils/errorTransform';
+import {
+    UpdateUserMutation,
+    UpdateUserMutationVariables,
+} from '#generated/types';
+import styles from './styles.css';
+
+const UPDATE_USER_EMAIL = gql`
+    mutation UpdateUser($userItem: UserUpdateInputType!) {
+        updateUser(data: $userItem) {
+            errors
+            result {
+                id
+                isActive
+                isAdmin
+                lastName
+                firstName
+                email
+                portfolioRole
+            }
+        }
+    }
+`;
+
+type EmailChangeFormFields = UpdateUserMutationVariables['userItem'];
+type FormType = PurgeNull<PartialForm<WithId<EmailChangeFormFields>>>;
+
+type FormSchema = ObjectSchema<FormType>;
+type FormSchemaFields = ReturnType<FormSchema['fields']>;
+
+const schema: FormSchema = {
+    fields: (): FormSchemaFields => ({
+        id: [idCondition],
+        email: [emailCondition],
+        firstName: [],
+        lastName: [],
+    }),
+};
+
+interface EmailChangeProps {
+    className?: string;
+    id?: string;
+}
+
+function UserEmailChangeForm(props: EmailChangeProps) {
+    const {
+        className,
+        id,
+    } = props;
+
+    const defaultFormValues: PartialForm<FormType> = {};
+
+    const {
+        pristine,
+        value,
+        error,
+        onValueChange,
+        validate,
+        onErrorSet,
+        onValueSet,
+        onPristineSet,
+    } = useForm(defaultFormValues, schema);
+
+    const {
+        notify,
+        notifyGQLError,
+    } = useContext(NotificationContext);
+
+    const [
+        updateUser,
+        { loading: updateLoading },
+    ] = useMutation<UpdateUserMutation, UpdateUserMutationVariables>(
+        UPDATE_USER_EMAIL,
+        {
+            onCompleted: (response) => {
+                const {
+                    updateUser: updateUserRes,
+                } = response;
+                if (!updateUserRes) {
+                    return;
+                }
+                const { errors, result } = updateUserRes;
+                if (errors) {
+                    const formError = transformToFormError(removeNull(errors));
+                    notifyGQLError(errors);
+                    onErrorSet(formError);
+                }
+                if (result) {
+                    notify({
+                        children: 'User email updated successfully!',
+                        variant: 'success',
+                    });
+                    onPristineSet(true);
+                }
+            },
+            onError: (errors) => {
+                notify({
+                    children: errors.message,
+                    variant: 'error',
+                });
+                onErrorSet({
+                    $internal: errors.message,
+                });
+            },
+        },
+    );
+
+    console.log('Check UserEmailChange::>>', id);
+
+    const handleSubmit = React.useCallback((finalValues: FormType) => {
+        if (finalValues.id) {
+            updateUser({
+                variables: {
+                    userItem: finalValues as WithId<EmailChangeFormFields>,
+                },
+            });
+        }
+    }, [updateUser]);
+
+    const loading = updateLoading;
+    const disabled = loading;
+
+    return (
+        <form
+            className={_cs(className, styles.parkedItemForm)}
+            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+        >
+            {loading && <Loading absolute />}
+            <NonFieldError>
+                {error?.$internal}
+            </NonFieldError>
+            <TextInput
+                label="First Name *"
+                name="firstName"
+                value={value.firstName}
+                onChange={onValueChange}
+                error={error?.fields?.firstName}
+                autoFocus
+                disabled={disabled}
+            />
+            <TextInput
+                label="Last Name"
+                name="lastName"
+                value={value.lastName}
+                onChange={onValueChange}
+                error={error?.fields?.lastName}
+                disabled={disabled}
+            />
+            <TextInput
+                label="Email"
+                name="email"
+                value={value.email}
+                onChange={onValueChange}
+                error={error?.fields?.email}
+                disabled={disabled}
+            />
+        </form>
+    );
+}
+
+export default UserEmailChangeForm;

--- a/src/components/forms/UserEmailChangeForm/styles.css
+++ b/src/components/forms/UserEmailChangeForm/styles.css
@@ -1,0 +1,3 @@
+.email-change {
+    display: flex;
+}

--- a/src/components/forms/UserEmailChangeForm/styles.css
+++ b/src/components/forms/UserEmailChangeForm/styles.css
@@ -1,3 +1,13 @@
 .email-change {
     display: flex;
+    position: relative;
+    flex-direction: column;
+    gap: var(--spacing-medium);
+
+    .form-buttons {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        gap: var(--spacing-medium);
+    }
 }

--- a/src/views/Admin/UserRoles/UserActions/index.tsx
+++ b/src/views/Admin/UserRoles/UserActions/index.tsx
@@ -4,10 +4,13 @@ import {
     IoLockOpenOutline,
     IoPersonRemoveOutline,
     IoPersonAddOutline,
+    IoCreateOutline,
 } from 'react-icons/io5';
 
 import Actions from '#components/Actions';
 import QuickActionConfirmButton from '#components/QuickActionConfirmButton';
+import QuickActionButton from '#components/QuickActionButton';
+
 import {
     UserListQuery,
 } from '#generated/types';
@@ -18,6 +21,7 @@ export interface ActionProps {
     id: string;
     className?: string;
     isAdmin?: boolean | null | undefined;
+    onEdit?: (id: string) => void;
     activeStatus?: boolean;
     user?: UserRolesField | undefined;
     onToggleUserActiveStatus?: (id: string, activeStatus: boolean) => void;
@@ -35,6 +39,7 @@ function ActionCell(props: ActionProps) {
         disabled,
         children,
         activeStatus,
+        onEdit,
         isAdmin,
     } = props;
 
@@ -59,6 +64,15 @@ function ActionCell(props: ActionProps) {
     return (
         <Actions className={className}>
             {children}
+            <QuickActionButton
+                name={id}
+                onClick={onEdit}
+                title="Edit"
+                disabled={disabled || !onEdit}
+                transparent
+            >
+                <IoCreateOutline />
+            </QuickActionButton>
             {onToggleRoleStatus && (
                 <QuickActionConfirmButton
                     name={undefined}

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -319,7 +319,7 @@ function UserRoles(props: UserRolesProps) {
                 'action',
                 '',
                 undefined,
-                2,
+                3,
             ),
         ]),
         [
@@ -373,7 +373,7 @@ function UserRoles(props: UserRolesProps) {
             {shouldShowEmailEditModal && (
                 <Modal
                     onClose={hideEmailEditModal}
-                    heading="Edit user email"
+                    heading="Update user"
                     size="small"
                     freeHeight
                 >

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -5,6 +5,7 @@ import {
     Table,
     useSortState,
     Pager,
+    Modal,
     SortContext,
     createYesNoColumn,
 } from '@togglecorp/toggle-ui';
@@ -24,6 +25,7 @@ import {
     ToggleUserRoleStatusMutationVariables,
 } from '#generated/types';
 import useDebouncedValue from '#hooks/useDebouncedValue';
+import useModalState from '#hooks/useModalState';
 
 import Message from '#components/Message';
 import NotificationContext from '#components/NotificationContext';
@@ -33,6 +35,7 @@ import Loading from '#components/Loading';
 import ActionCell, { ActionProps } from './UserActions';
 import UserFilter from './UserFilter/index';
 import styles from './styles.css';
+import UserEmailChangeForm from '#components/forms/UserEmailChangeForm';
 
 const GET_USERS_LIST = gql`
     query UserList(
@@ -129,6 +132,13 @@ function UserRoles(props: UserRolesProps) {
         usersQueryFilters,
         setUsersQueryFilters,
     ] = useState<PurgeNull<UserListQueryVariables>>();
+
+    const [
+        shouldShowEmailEditModal,
+        editableUserId,
+        showEmailEditModal,
+        hideEmailEditModal,
+    ] = useModalState();
 
     const onFilterChange = React.useCallback(
         (value: PurgeNull<UserListQueryVariables>) => {
@@ -302,6 +312,7 @@ function UserRoles(props: UserRolesProps) {
                     id: datum.id,
                     activeStatus: datum.isActive,
                     isAdmin: datum.isAdmin,
+                    onEdit: showEmailEditModal,
                     onToggleUserActiveStatus: handleToggleUserActiveStatus,
                     onToggleRoleStatus: handleToggleRoleStatus,
                 }),
@@ -312,6 +323,7 @@ function UserRoles(props: UserRolesProps) {
             ),
         ]),
         [
+            showEmailEditModal,
             handleToggleUserActiveStatus,
             handleToggleRoleStatus,
         ],
@@ -357,6 +369,16 @@ function UserRoles(props: UserRolesProps) {
                 <Message
                     message="No users found."
                 />
+            )}
+            {shouldShowEmailEditModal && (
+                <Modal
+                    onClose={hideEmailEditModal}
+                    heading="Edit user email"
+                    size="small"
+                    freeHeight
+                >
+                    <UserEmailChangeForm id={editableUserId} />
+                </Modal>
             )}
         </Container>
     );

--- a/src/views/Admin/UserRoles/index.tsx
+++ b/src/views/Admin/UserRoles/index.tsx
@@ -377,7 +377,10 @@ function UserRoles(props: UserRolesProps) {
                     size="small"
                     freeHeight
                 >
-                    <UserEmailChangeForm id={editableUserId} />
+                    <UserEmailChangeForm
+                        id={editableUserId}
+                        onEmailChangeFormCancel={hideEmailEditModal}
+                    />
                 </Modal>
             )}
         </Container>


### PR DESCRIPTION
## Addresses:
- Issue: https://github.com/idmc-labs/helix2.0-meta/issues/191#issuecomment-1576468157

## Depends on:
- Server branch:  https://github.com/idmc-labs/helix-server/pull/493#issue-1735771174

## Changes:
- Add an edit button for each row in the ADMIN section
- Enable edit mode for each user using a modal that contains firstName, lastName and Email as the input fields

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
