### PR TITLE
Add feature to add user as director's office and reporting team

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           ENVIRONMENT: "staging"
           REACT_APP_ENV: "staging"
           REACT_APP_GRAPHQL_ENDPOINT: "https://helix-tools-api-staging.idmcdb.org/graphql"
+          REACT_APP_GRAPHIQL_ENDPOINT: "https://helix-tools-api-staging.idmcdb.org/graphiql"
+          REACT_APP_SWAGGER_ENDPOINT:  "https://helix-tools-api-staging.idmcdb.org/external-api/"
           GRAPHQL_CODEGEN_ENDPOINT: "https://helix-tools-api-staging.idmcdb.org/graphql"
           REACT_APP_MMP_ENDPOINT: "https://media-monitoring.idmcdb.org"
           REACT_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.REACT_APP_MAPBOX_ACCESS_TOKEN }}
@@ -57,6 +59,8 @@ jobs:
           ENVIRONMENT: "prod"
           REACT_APP_ENV: "prod"
           REACT_APP_GRAPHQL_ENDPOINT: "https://helix-tools-api.idmcdb.org/graphql"
+          REACT_APP_GRAPHIQL_ENDPOINT: "https://helix-tools-api.idmcdb.org/graphiql"
+          REACT_APP_SWAGGER_ENDPOINT:  "https://helix-tools-api.idmcdb.org/external-api/"
           GRAPHQL_CODEGEN_ENDPOINT: "https://helix-tools-api.idmcdb.org/graphql"
           REACT_APP_MMP_ENDPOINT: "https://media-monitoring.idmcdb.org"
           REACT_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.REACT_APP_MAPBOX_ACCESS_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       REACT_APP_ENV: ${REACT_APP_ENV:-dev}
       REACT_APP_GRAPHQL_ENDPOINT: ${REACT_APP_GRAPHQL_ENDPOINT:-http://localhost:9000/graphql}
+      REACT_APP_GRAPHIQL_ENDPOINT: ${REACT_APP_GRAPHIQL_ENDPOINT:-http://localhost:9000/graphiql}
+      REACT_APP_SWAGGER_ENDPOINT: ${REACT_APP_SWAGGER_ENDPOINT:-http://localhost:9000/external-api/}
       GRAPHQL_CODEGEN_ENDPOINT: ${GRAPHQL_CODEGEN_ENDPOINT:-http://host.docker.internal:9000/graphql}
       REACT_APP_HCATPCHA_SITEKEY: ${REACT_APP_HCATPCHA_SITEKEY:-10000000-ffff-ffff-ffff-000000000001}
       REACT_APP_MMP_ENDPOINT: ${REACT_APP_MMP_ENDPOINT:-https://media-monitoring.idmcdb.org}

--- a/src/views/Admin/UserRoles/UserActions/index.tsx
+++ b/src/views/Admin/UserRoles/UserActions/index.tsx
@@ -2,9 +2,10 @@ import React, { useCallback } from 'react';
 import {
     IoLockClosedOutline,
     IoLockOpenOutline,
-    IoPersonRemoveOutline,
-    IoPersonAddOutline,
+    IoRocketOutline,
     IoCreateOutline,
+    IoBarChartOutline,
+    IoBusinessOutline,
 } from 'react-icons/io5';
 
 import Actions from '#components/Actions';
@@ -20,27 +21,35 @@ type UserRolesField = NonNullable<NonNullable<UserListQuery['users']>['results']
 export interface ActionProps {
     id: string;
     className?: string;
-    isAdmin?: boolean | null | undefined;
-    onEdit?: (id: string) => void;
-    activeStatus?: boolean;
-    user?: UserRolesField | undefined;
-    onToggleUserActiveStatus?: (id: string, activeStatus: boolean) => void;
-    onToggleRoleStatus?: (id: string, isAdmin: boolean) => void;
     disabled?: boolean;
     children?: React.ReactNode;
+    onEdit?: (id: string) => void;
+    user?: UserRolesField | undefined;
+    activeStatus?: boolean;
+    onToggleUserActiveStatus?: (id: string, activeStatus: boolean) => void;
+    isAdmin?: boolean | null | undefined;
+    onToggleAdminStatus?: (id: string, isAdmin: boolean) => void;
+    isDirectorsOffice?: boolean | null | undefined;
+    onToggleDirectorsOfficeStatus?: (id: string, isDirectorsOffice: boolean) => void;
+    isReportingTeam?: boolean | null | undefined;
+    onToggleReportingTeamStatus?: (id: string, isDirectorsOffice: boolean) => void;
 }
 
 function ActionCell(props: ActionProps) {
     const {
         className,
         id,
-        onToggleRoleStatus,
+        onToggleAdminStatus,
         onToggleUserActiveStatus,
         disabled,
         children,
         activeStatus,
         onEdit,
         isAdmin,
+        isDirectorsOffice,
+        onToggleDirectorsOfficeStatus,
+        isReportingTeam,
+        onToggleReportingTeamStatus,
     } = props;
 
     const handleToggleUserActiveStatus = React.useCallback(
@@ -52,13 +61,31 @@ function ActionCell(props: ActionProps) {
         [onToggleUserActiveStatus, id, activeStatus],
     );
 
-    const handleToggleRoleStatus = useCallback(
+    const handleToggleAdminStatus = useCallback(
         () => {
-            if (onToggleRoleStatus) {
-                onToggleRoleStatus(id, !!isAdmin);
+            if (onToggleAdminStatus) {
+                onToggleAdminStatus(id, !!isAdmin);
             }
         },
-        [onToggleRoleStatus, id, isAdmin],
+        [onToggleAdminStatus, id, isAdmin],
+    );
+
+    const handleToggleDirectorsOfficeStatus = useCallback(
+        () => {
+            if (onToggleDirectorsOfficeStatus) {
+                onToggleDirectorsOfficeStatus(id, !!isDirectorsOffice);
+            }
+        },
+        [onToggleDirectorsOfficeStatus, id, isDirectorsOffice],
+    );
+
+    const handleToggleReportingTeamStatus = useCallback(
+        () => {
+            if (onToggleReportingTeamStatus) {
+                onToggleReportingTeamStatus(id, !!isReportingTeam);
+            }
+        },
+        [onToggleReportingTeamStatus, id, isReportingTeam],
     );
 
     return (
@@ -73,17 +100,43 @@ function ActionCell(props: ActionProps) {
             >
                 <IoCreateOutline />
             </QuickActionButton>
-            {onToggleRoleStatus && (
+            {onToggleAdminStatus && (
                 <QuickActionConfirmButton
                     name={undefined}
-                    onConfirm={handleToggleRoleStatus}
+                    onConfirm={handleToggleAdminStatus}
                     title={!isAdmin ? 'Grant admin access' : 'Revoke admin access'}
                     variant={isAdmin ? 'danger' : 'default'}
-                    disabled={disabled || !onToggleRoleStatus}
+                    disabled={disabled || !onToggleAdminStatus}
                     confirmationMessage="Are you sure you want to change the user admin access?"
                     transparent
                 >
-                    {!isAdmin ? <IoPersonAddOutline /> : <IoPersonRemoveOutline />}
+                    <IoRocketOutline />
+                </QuickActionConfirmButton>
+            )}
+            {onToggleDirectorsOfficeStatus && (
+                <QuickActionConfirmButton
+                    name={undefined}
+                    onConfirm={handleToggleDirectorsOfficeStatus}
+                    title={!isDirectorsOffice ? 'Grant director\'s office access' : 'Revoke director\'s office access'}
+                    variant={isDirectorsOffice ? 'danger' : 'default'}
+                    disabled={disabled || !onToggleDirectorsOfficeStatus}
+                    confirmationMessage="Are you sure you want to change the user director's office access?"
+                    transparent
+                >
+                    <IoBusinessOutline />
+                </QuickActionConfirmButton>
+            )}
+            {onToggleReportingTeamStatus && (
+                <QuickActionConfirmButton
+                    name={undefined}
+                    onConfirm={handleToggleReportingTeamStatus}
+                    title={!isReportingTeam ? 'Grant reporting team access' : 'Revoke reporting team access'}
+                    variant={isReportingTeam ? 'danger' : 'default'}
+                    disabled={disabled || !onToggleReportingTeamStatus}
+                    confirmationMessage="Are you sure you want to change the user reporting team access?"
+                    transparent
+                >
+                    <IoBarChartOutline />
                 </QuickActionConfirmButton>
             )}
             {onToggleUserActiveStatus && (

--- a/src/views/ApiUsage/index.tsx
+++ b/src/views/ApiUsage/index.tsx
@@ -16,6 +16,9 @@ import ApiLogsTable from './ApiRecordsTable';
 
 import styles from './styles.css';
 
+const GRAPHIQL_ENDPOINT = process.env.REACT_APP_GRAPHIQL_ENDPOINT as string;
+const SWAGGER_ENDPOINT = process.env.REACT_APP_SWAGGER_ENDPOINT as string;
+
 interface TabReduxProps {
     children: React.ReactNode;
     className?: string;
@@ -95,6 +98,34 @@ function ApiUsage(props: ApiUsageProps) {
                                 Clients
                             </TabRedux>
                         </Container>
+                        {(GRAPHIQL_ENDPOINT || SWAGGER_ENDPOINT) && (
+                            <Container
+                                className={styles.sidePaneContainer}
+                                contentClassName={styles.sidePaneContent}
+                                heading="APIs"
+                            >
+                                {GRAPHIQL_ENDPOINT && (
+                                    <a
+                                        className={styles.link}
+                                        href={GRAPHIQL_ENDPOINT}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        Graphiql (Graphql API)
+                                    </a>
+                                )}
+                                {SWAGGER_ENDPOINT && (
+                                    <a
+                                        className={styles.link}
+                                        href={SWAGGER_ENDPOINT}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        Swagger (REST API)
+                                    </a>
+                                )}
+                            </Container>
+                        )}
                     </div>
                 </div>
                 <div className={styles.mainContent}>

--- a/src/views/ApiUsage/styles.css
+++ b/src/views/ApiUsage/styles.css
@@ -31,6 +31,11 @@
                 display: flex;
                 position: relative;
                 flex-direction: column;
+
+
+                .link {
+                    padding: var(--spacing-small) var(--spacing-medium);
+                }
             }
         }
     }

--- a/src/views/Crisis/index.tsx
+++ b/src/views/Crisis/index.tsx
@@ -44,6 +44,7 @@ const CRISIS = gql`
             startDate
             totalFlowNdFigures
             totalStockIdpFigures
+            stockIdpFiguresMaxEndDate
         }
     }
 `;
@@ -111,8 +112,16 @@ function Crisis(props: CrisisProps) {
                             value={crisisData?.crisis?.totalFlowNdFigures}
                         />
                         <NumberBlock
-                            label="No. of IDPs"
+                            label={
+                                crisisData?.crisis?.stockIdpFiguresMaxEndDate
+                                    ? `No. of IDPs as of ${crisisData.crisis.stockIdpFiguresMaxEndDate}`
+                                    : 'No. of IDPs'
+                            }
                             value={crisisData?.crisis?.totalStockIdpFigures}
+                        />
+                        <TextBlock
+                            label="As of"
+                            value={crisisData?.crisis?.stockIdpFiguresMaxEndDate}
                         />
                         <TextBlock
                             label="Start Date"

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -39,6 +39,7 @@ const EVENT = gql`
             eventTypeDisplay
             totalFlowNdFigures
             totalStockIdpFigures
+            stockIdpFiguresMaxEndDate
             reviewStatus
             crisis {
                 id
@@ -214,7 +215,11 @@ function Event(props: EventProps) {
                                 value={eventData?.event?.totalFlowNdFigures}
                             />
                             <NumberBlock
-                                label="No. of IDPs"
+                                label={
+                                    eventData?.event?.stockIdpFiguresMaxEndDate
+                                        ? `No. of IDPs as of ${eventData.event.stockIdpFiguresMaxEndDate}`
+                                        : 'No. of IDPs'
+                                }
                                 value={eventData?.event?.totalStockIdpFigures}
                             />
                             <TextBlock


### PR DESCRIPTION
- Add links to graphiql and swagger endpoints
- Show which date was used to calcualte stock data on crisis and event

## Depends on
- https://github.com/idmc-labs/helix-server/pull/505

## Addresses
- https://github.com/idmc-labs/helix2.0-meta/issues/863
- https://github.com/idmc-labs/helix2.0-meta/issues/264
- https://github.com/idmc-labs/helix2.0-meta/issues/696

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations