### PR TITLE
Add columns on API usage table

### DIFF
--- a/src/components/forms/EntryForm/schema.ts
+++ b/src/components/forms/EntryForm/schema.ts
@@ -12,6 +12,9 @@ import {
     Schema,
     ArraySchema,
 } from '@togglecorp/toggle-form';
+import {
+    isNotDefined,
+} from '@togglecorp/fujs';
 
 import { PartialForm } from '#types';
 import {
@@ -26,6 +29,7 @@ import {
     isFlowCategory,
     isHousingTerm,
     isDisplacementTerm,
+    isStockCategory,
 } from '#utils/selectionConstants';
 import {
     Unit,
@@ -33,6 +37,16 @@ import {
     Figure_Category_Types as FigureCategoryTypes,
     Crisis_Type as CrisisType,
 } from '#generated/types';
+
+function pastDateCondition(value: string | null | undefined) {
+    if (isNotDefined(value)) {
+        return undefined;
+    }
+    if (new Date(value) <= new Date()) {
+        return undefined;
+    }
+    return 'Date should not be in the future';
+}
 
 // FIXME: the comparison should be type-safe but
 // we are currently downcasting string literals to string
@@ -163,7 +177,7 @@ const figure: Figure = {
             quantifier: [requiredCondition],
             reported: [requiredCondition, integerCondition, greaterThanOrEqualToCondition(0)],
             role: [requiredCondition],
-            startDate: [requiredStringCondition],
+            startDate: [requiredStringCondition, pastDateCondition],
             startDateAccuracy: [],
             country: [requiredCondition],
             term: [requiredCondition],
@@ -174,7 +188,9 @@ const figure: Figure = {
             sources: [requiredListCondition, arrayCondition],
             geoLocations,
 
-            endDate: [requiredCondition],
+            endDate: isStockCategory(value?.category)
+                ? [requiredCondition]
+                : [requiredCondition, pastDateCondition],
             endDateAccuracy: [nullCondition],
             householdSize: [nullCondition],
 

--- a/src/components/tableHelpers/ExternalLink/index.tsx
+++ b/src/components/tableHelpers/ExternalLink/index.tsx
@@ -19,7 +19,7 @@ function ExternalLinkCell(props: ExternalLinkProps) {
         className,
     } = props;
 
-    if (!title) {
+    if (isFalsyString(title)) {
         return null;
     }
 

--- a/src/views/ApiUsage/ApiRecordsTable/index.tsx
+++ b/src/views/ApiUsage/ApiRecordsTable/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@togglecorp/toggle-ui';
 import {
     createTextColumn,
+    createExternalLinkColumn,
     createDateColumn,
     createNumberColumn,
 } from '#components/tableHelpers';
@@ -76,6 +77,10 @@ const CLIENT_TRACK_INFORMATION_LIST = gql`
                     code
                 }
                 apiTypeDisplay
+                description
+                exampleRequest
+                responseType
+                usage
             }
         }
     }
@@ -235,11 +240,33 @@ function ApiRecordsTable(props: ApiRecordProps) {
 
     const columns = useMemo(
         () => ([
-            createTextColumn<ApiFields, string>(
-                'api_name',
+            createExternalLinkColumn<ApiFields, string>(
+                'api_type_display',
                 'API',
-                (item) => item.apiTypeDisplay,
-                { sortable: true },
+                (item) => ({
+                    title: item.apiTypeDisplay,
+                    link: item.exampleRequest,
+                }),
+            ),
+            createTextColumn<ApiFields, string>(
+                'response_type',
+                'API Response',
+                (item) => item.responseType,
+            ),
+            createTextColumn<ApiFields, string>(
+                'usage',
+                'API Usage',
+                (item) => item.usage,
+            ),
+            createTextColumn<ApiFields, string>(
+                'description',
+                'API Description',
+                (item) => item.description,
+            ),
+            createTextColumn<ApiFields, string>(
+                'client__name',
+                'Client Name',
+                (item) => item.client?.name,
             ),
             createTextColumn<ApiFields, string>(
                 'client__code',


### PR DESCRIPTION
- Limit adding future dates on start date, end date and stock date on figures

## Depends on 
- https://github.com/idmc-labs/helix-server/pull/521

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
