### PR TITLE
Update filters

### DIFF
--- a/src/components/rawTables/EntriesTable/AdvancedEntriesFilter/index.tsx
+++ b/src/components/rawTables/EntriesTable/AdvancedEntriesFilter/index.tsx
@@ -549,7 +549,7 @@ function ExtractionFilters(props: ExtractionFiltersProps) {
                             onChange={onValueChange}
                             disabled={disabled}
                             onOptionsChange={setCrises}
-                            countries={value.filterFigureCountries}
+                            // countries={value.filterFigureCountries}
                         />
                         <EventMultiSelectInput
                             label="Events"

--- a/src/components/rawTables/EntriesTable/EntriesFilter/index.tsx
+++ b/src/components/rawTables/EntriesTable/EntriesFilter/index.tsx
@@ -129,12 +129,15 @@ const schema: FormSchema = {
 interface EntriesFilterProps {
     className?: string;
     onFilterChange: (value: PurgeNull<ExtractionEntryListFiltersQueryVariables>) => void;
+    disabled?: boolean;
+
     reviewStatusHidden?: boolean;
     countriesHidden?: boolean;
     eventsHidden?: boolean;
+
     defaultCountries?: string[];
+    defaultCrises?: string[];
     defaultEvents?: string[];
-    disabled?: boolean;
 }
 
 function EntriesFilter(props: EntriesFilterProps) {
@@ -143,6 +146,7 @@ function EntriesFilter(props: EntriesFilterProps) {
         onFilterChange,
         reviewStatusHidden,
         disabled,
+        defaultCrises,
         defaultCountries,
         defaultEvents,
         countriesHidden,
@@ -313,6 +317,9 @@ function EntriesFilter(props: EntriesFilterProps) {
                         onChange={onValueChange}
                         error={error?.fields?.filterFigureCountries?.$internal}
                         disabled={disabled}
+                        // defaultCountries={defaultCountries}
+                        defaultCrises={defaultCrises}
+                        defaultEvents={defaultEvents}
                     />
                 )}
                 {!eventsHidden && (
@@ -325,6 +332,8 @@ function EntriesFilter(props: EntriesFilterProps) {
                         value={value.filterFigureEvents}
                         error={error?.fields?.filterFigureEvents?.$internal}
                         disabled={disabled}
+                        defaultCountries={defaultCountries}
+                        defaultCrises={defaultCrises}
                     />
                 )}
                 <MultiSelectInput

--- a/src/components/rawTables/EventsTable/EventsFilter/index.tsx
+++ b/src/components/rawTables/EventsTable/EventsFilter/index.tsx
@@ -191,14 +191,16 @@ interface EventsFilterProps {
 
     defaultCreatedByIds?: string[];
     defaultCountries?: string[];
+    defaultEvents?: string[];
+    defaultCrises?: string[];
 
     defaultCreatedByOptions?: UserOption[];
     defaultCountriesOptions?: CountryOption[];
 
-    reviewStatusSelectionDisabled: boolean;
-    crisisSelectionDisabled: boolean;
-    createdBySelectionDisabled: boolean;
     countriesSelectionDisabled: boolean;
+    crisisSelectionDisabled: boolean;
+    reviewStatusSelectionDisabled: boolean;
+    createdBySelectionDisabled: boolean;
 }
 
 function EventsFilter(props: EventsFilterProps) {
@@ -212,6 +214,8 @@ function EventsFilter(props: EventsFilterProps) {
 
         defaultCreatedByIds,
         defaultCountries,
+        defaultEvents,
+        defaultCrises,
         defaultCreatedByOptions,
         defaultCountriesOptions,
     } = props;
@@ -431,6 +435,7 @@ function EventsFilter(props: EventsFilterProps) {
                         onChange={onValueChange}
                         // disabled={disabled}
                         onOptionsChange={setCrisesByIds}
+                        defaultCountries={defaultCountries}
                     />
                 )}
                 {!countriesSelectionDisabled && (
@@ -443,6 +448,8 @@ function EventsFilter(props: EventsFilterProps) {
                         value={value.countries}
                         onChange={onValueChange}
                         error={error?.fields?.countries?.$internal}
+                        defaultCrises={defaultCrises}
+                        defaultEvents={defaultEvents}
                     />
                 )}
                 <div className={styles.formButtons}>

--- a/src/components/selections/CountryMultiSelectInput/index.tsx
+++ b/src/components/selections/CountryMultiSelectInput/index.tsx
@@ -15,8 +15,20 @@ import { GetCountriesQuery, GetCountriesQueryVariables } from '#generated/types'
 import styles from './styles.css';
 
 const COUNTRIES = gql`
-    query GetCountries($search: String, $regions: [String!], $ordering: String) {
-        countryList(countryName: $search, regionByIds: $regions, ordering: $ordering) {
+    query GetCountries(
+        $search: String,
+        $regions: [String!],
+        $events: [ID!],
+        $crises: [ID!],
+        $ordering: String,
+    ) {
+        countryList(
+            countryName: $search,
+            regionByIds: $regions,
+            ordering: $ordering,
+            events: $events,
+            crises: $crises,
+        ) {
             totalCount
             results {
                 id
@@ -43,13 +55,17 @@ type SelectInputProps<
     Def,
     'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
 > & {
-    regions?: string[],
+    defaultRegions?: string[],
+    defaultEvents?: string[];
+    defaultCrises?: string[];
 };
 
 function CountryMultiSelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
         className,
-        regions,
+        defaultRegions,
+        defaultEvents,
+        defaultCrises,
         ...otherProps
     } = props;
 
@@ -61,14 +77,21 @@ function CountryMultiSelectInput<K extends string>(props: SelectInputProps<K>) {
     const searchVariable = useMemo(
         (): GetCountriesQueryVariables => {
             if (!debouncedSearchText) {
-                return { ordering: 'idmcShortName' };
+                return {
+                    ordering: 'idmcShortName',
+                    regions: defaultRegions ?? undefined,
+                    events: defaultEvents,
+                    crises: defaultCrises,
+                };
             }
             return {
                 search: debouncedSearchText,
-                regions: regions ?? undefined,
+                regions: defaultRegions ?? undefined,
+                events: defaultEvents,
+                crises: defaultCrises,
             };
         },
-        [debouncedSearchText, regions],
+        [debouncedSearchText, defaultRegions, defaultEvents, defaultCrises],
     );
 
     const {

--- a/src/components/selections/CountrySelectInput/index.tsx
+++ b/src/components/selections/CountrySelectInput/index.tsx
@@ -15,8 +15,20 @@ import { GetCountryQuery, GetCountryQueryVariables } from '#generated/types';
 import styles from './styles.css';
 
 const COUNTRY = gql`
-    query GetCountry($search: String, $ordering: String) {
-        countryList(countryName: $search, ordering: $ordering) {
+    query GetCountry(
+        $search: String,
+        $regions: [String!],
+        $events: [ID!],
+        $crises: [ID!],
+        $ordering: String,
+    ) {
+        countryList(
+            countryName: $search,
+            regionByIds: $regions,
+            ordering: $ordering,
+            events: $events,
+            crises: $crises,
+        ) {
             totalCount
             results {
                 id
@@ -42,11 +54,18 @@ type SelectInputProps<
     CountryOption,
     Def,
     'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalCount'
->;
+> & {
+    defaultRegions?: string[],
+    defaultEvents?: string[];
+    defaultCrises?: string[];
+};
 
 function CountrySelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
         className,
+        defaultRegions,
+        defaultEvents,
+        defaultCrises,
         ...otherProps
     } = props;
 
@@ -56,10 +75,23 @@ function CountrySelectInput<K extends string>(props: SelectInputProps<K>) {
     const debouncedSearchText = useDebouncedValue(searchText);
 
     const searchVariable = useMemo(
-        (): GetCountryQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: 'idmcShortName' }
-        ),
-        [debouncedSearchText],
+        (): GetCountryQueryVariables => {
+            if (!debouncedSearchText) {
+                return {
+                    ordering: 'idmcShortName',
+                    regions: defaultRegions ?? undefined,
+                    events: defaultEvents,
+                    crises: defaultCrises,
+                };
+            }
+            return {
+                search: debouncedSearchText,
+                regions: defaultRegions ?? undefined,
+                events: defaultEvents,
+                crises: defaultCrises,
+            };
+        },
+        [debouncedSearchText, defaultRegions, defaultEvents, defaultCrises],
     );
 
     const {

--- a/src/components/selections/CrisisMultiSelectInput/index.tsx
+++ b/src/components/selections/CrisisMultiSelectInput/index.tsx
@@ -41,13 +41,13 @@ type SelectInputProps<
     Def,
     'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
 > & {
-    countries?: string[],
+    defaultCountries?: string[],
 };
 
 function CrisisMultiSelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
         className,
-        countries,
+        defaultCountries,
         ...otherProps
     } = props;
 
@@ -59,14 +59,17 @@ function CrisisMultiSelectInput<K extends string>(props: SelectInputProps<K>) {
     const searchVariable = useMemo(
         (): GetCrisesQueryVariables => {
             if (!debouncedSearchText) {
-                return { ordering: '-createdAt' };
+                return {
+                    ordering: '-createdAt',
+                    countries: defaultCountries ?? undefined,
+                };
             }
             return {
                 search: debouncedSearchText,
-                countries: countries ?? undefined,
+                countries: defaultCountries ?? undefined,
             };
         },
-        [debouncedSearchText, countries],
+        [debouncedSearchText, defaultCountries],
     );
 
     const {

--- a/src/components/selections/CrisisSelectInput/index.tsx
+++ b/src/components/selections/CrisisSelectInput/index.tsx
@@ -15,8 +15,8 @@ import { GetCrisisQuery, GetCrisisQueryVariables } from '#generated/types';
 import styles from './styles.css';
 
 const CRISIS = gql`
-    query GetCrisis($search: String, $ordering: String) {
-        crisisList(name: $search, ordering: $ordering) {
+    query GetCrisis($search: String, $countries: [String!], $ordering: String) {
+        crisisList(name: $search, countries: $countries, ordering: $ordering) {
             totalCount
             results {
                 id
@@ -40,11 +40,14 @@ type SelectInputProps<
     CrisisOption,
     Def,
     'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
->;
+> & {
+    defaultCountries?: string[],
+};
 
 function CrisisSelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
         className,
+        defaultCountries,
         ...otherProps
     } = props;
 
@@ -54,10 +57,19 @@ function CrisisSelectInput<K extends string>(props: SelectInputProps<K>) {
     const debouncedSearchText = useDebouncedValue(searchText);
 
     const searchVariable = useMemo(
-        (): GetCrisisQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: '-createdAt' }
-        ),
-        [debouncedSearchText],
+        (): GetCrisisQueryVariables => {
+            if (!debouncedSearchText) {
+                return {
+                    ordering: '-createdAt',
+                    countries: defaultCountries ?? undefined,
+                };
+            }
+            return {
+                search: debouncedSearchText,
+                countries: defaultCountries ?? undefined,
+            };
+        },
+        [debouncedSearchText, defaultCountries],
     );
 
     const {

--- a/src/components/selections/EventListSelectInput/index.tsx
+++ b/src/components/selections/EventListSelectInput/index.tsx
@@ -19,8 +19,18 @@ import styles from './styles.css';
 
 const EVENT_LIST = gql`
     ${EVENT_FRAGMENT}
-    query GetEventList($search: String, $ordering: String) {
-        eventList(name: $search, ordering: $ordering) {
+    query GetEventList(
+        $search: String,
+        $crises: [ID!],
+        $countries: [ID!],
+        $ordering: String,
+    ) {
+        eventList(
+            name: $search,
+            ordering: $ordering,
+            crisisByIds: $crises,
+            countries: $countries,
+        ) {
             totalCount
             results {
                 ...EventResponse
@@ -37,13 +47,16 @@ const labelSelector = (d: EventListOption) => d.name;
 type Def = { containerClassName?: string };
 type SelectInputProps<
     K extends string,
-    > = SearchSelectInputProps<
-        string,
-        K,
-        EventListOption,
-        Def,
-        'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
-    >;
+> = SearchSelectInputProps<
+    string,
+    K,
+    EventListOption,
+    Def,
+    'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
+> & {
+    defaultCountries?: string[];
+    defaultCrises?: string[];
+};
 
 function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
@@ -51,6 +64,8 @@ function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
         value,
         options,
         disabled,
+        defaultCountries,
+        defaultCrises,
         ...otherProps
     } = props;
 
@@ -61,9 +76,17 @@ function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
 
     const searchVariable = useMemo(
         (): GetEventListQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: '-createdAt' }
+            debouncedSearchText ? {
+                search: debouncedSearchText,
+                countries: defaultCountries,
+                crises: defaultCrises,
+            } : {
+                ordering: '-createdAt',
+                countries: defaultCountries,
+                crises: defaultCrises,
+            }
         ),
-        [debouncedSearchText],
+        [debouncedSearchText, defaultCountries, defaultCrises],
     );
 
     const {

--- a/src/components/selections/EventMultiSelectInput/index.tsx
+++ b/src/components/selections/EventMultiSelectInput/index.tsx
@@ -16,8 +16,18 @@ import SearchMultiSelectInputWithChip from '#components/SearchMultiSelectInputWi
 import styles from './styles.css';
 
 const EVENT = gql`
-    query GetEvent($search: String, $ordering: String) {
-        eventList(name: $search, ordering: $ordering) {
+    query GetEvent(
+        $search: String,
+        $crises: [ID!],
+        $countries: [ID!],
+        $ordering: String,
+    ) {
+        eventList(
+            name: $search,
+            ordering: $ordering,
+            crisisByIds: $crises,
+            countries: $countries,
+        ) {
             totalCount
             results {
                 id
@@ -35,18 +45,24 @@ const labelSelector = (d: EventOption) => d.name;
 type Def = { containerClassName?: string };
 type MultiSelectInputProps<
     K extends string,
-    > = SearchMultiSelectInputProps<
-        string,
-        K,
-        EventOption,
-        Def,
-        'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
-    > & { chip?: boolean };
+> = SearchMultiSelectInputProps<
+    string,
+    K,
+    EventOption,
+    Def,
+    'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
+> & {
+    chip?: boolean,
+    defaultCountries?: string[];
+    defaultCrises?: string[];
+};
 
 function EventMultiSelectInput<K extends string>(props: MultiSelectInputProps<K>) {
     const {
         className,
         chip,
+        defaultCountries,
+        defaultCrises,
         ...otherProps
     } = props;
 
@@ -57,9 +73,17 @@ function EventMultiSelectInput<K extends string>(props: MultiSelectInputProps<K>
 
     const searchVariable = useMemo(
         (): GetEventQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: '-createdAt' }
+            debouncedSearchText ? {
+                search: debouncedSearchText,
+                countries: defaultCountries,
+                crises: defaultCrises,
+            } : {
+                ordering: '-createdAt',
+                countries: defaultCountries,
+                crises: defaultCrises,
+            }
         ),
-        [debouncedSearchText],
+        [debouncedSearchText, defaultCountries, defaultCrises],
     );
 
     const {

--- a/src/components/selections/EventSelectInput/index.tsx
+++ b/src/components/selections/EventSelectInput/index.tsx
@@ -15,8 +15,18 @@ import { GetEventQuery, GetEventQueryVariables } from '#generated/types';
 import styles from './styles.css';
 
 const EVENT = gql`
-    query GetEvent($search: String, $ordering: String) {
-        eventList(name: $search, ordering: $ordering) {
+    query GetEvent(
+        $search: String,
+        $crises: [ID!],
+        $countries: [ID!],
+        $ordering: String,
+    ) {
+        eventList(
+            name: $search,
+            ordering: $ordering,
+            crisisByIds: $crises,
+            countries: $countries,
+        ) {
             totalCount
             results {
                 id
@@ -40,11 +50,16 @@ type SelectInputProps<
     EventOption,
     Def,
     'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount'
->;
+> & {
+    defaultCountries?: string[];
+    defaultCrises?: string[];
+};
 
 function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
     const {
         className,
+        defaultCountries,
+        defaultCrises,
         ...otherProps
     } = props;
 
@@ -55,9 +70,17 @@ function EventSelectInput<K extends string>(props: SelectInputProps<K>) {
 
     const searchVariable = useMemo(
         (): GetEventQueryVariables => (
-            debouncedSearchText ? { search: debouncedSearchText } : { ordering: '-createdAt' }
+            debouncedSearchText ? {
+                search: debouncedSearchText,
+                countries: defaultCountries,
+                crises: defaultCrises,
+            } : {
+                ordering: '-createdAt',
+                countries: defaultCountries,
+                crises: defaultCrises,
+            }
         ),
-        [debouncedSearchText],
+        [debouncedSearchText, defaultCountries, defaultCrises],
     );
 
     const {

--- a/src/components/tables/EntriesFiguresTable/index.tsx
+++ b/src/components/tables/EntriesFiguresTable/index.tsx
@@ -47,6 +47,7 @@ interface EntriesFiguresTableProps {
     eventColumnHidden?: boolean;
     crisisColumnHidden?: boolean;
 
+    crisisId?: string;
     eventId?: string;
     userId?: string;
     countryId?: string;
@@ -65,6 +66,7 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
         userId,
         countryId,
         eventId,
+        crisisId,
         reviewStatus,
     } = props;
 
@@ -109,13 +111,16 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
             ordering: entriesOrdering,
             page: entriesPage,
             pageSize: entriesPageSize,
+            ...entriesQueryFilters,
+            filterFigureCrises: crisisId
+                ? [crisisId]
+                : entriesQueryFilters?.filterFigureCrises,
             filterFigureEvents: eventId ? [eventId] : undefined,
             filterCreatedBy: userId ? [userId] : undefined,
             filterFigureCountries: countryId ? [countryId] : undefined,
             filterFigureReviewStatus: reviewStatus
                 ? [reviewStatus]
                 : entriesQueryFilters?.filterFigureReviewStatus,
-            ...entriesQueryFilters,
         }),
         [
             entriesOrdering,
@@ -123,6 +128,7 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
             entriesPageSize,
             eventId,
             userId,
+            crisisId,
             countryId,
             entriesQueryFilters,
             reviewStatus,
@@ -134,19 +140,23 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
             ordering: figuresOrdering,
             page: figuresPage,
             pageSize: figuresPageSize,
+            ...entriesQueryFilters,
+            filterFigureCrises: crisisId
+                ? [crisisId]
+                : entriesQueryFilters?.filterFigureCrises,
             filterFigureEvents: eventId ? [eventId] : undefined,
             filterCreatedBy: userId ? [userId] : undefined,
             filterFigureCountries: countryId ? [countryId] : undefined,
             filterFigureReviewStatus: reviewStatus
                 ? [reviewStatus]
                 : entriesQueryFilters?.filterFigureReviewStatus,
-            ...entriesQueryFilters,
         }),
         [
             figuresOrdering,
             figuresPage,
             figuresPageSize,
             eventId,
+            crisisId,
             userId,
             countryId,
             entriesQueryFilters,
@@ -233,6 +243,7 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
                                 eventsHidden={isDefined(eventId)}
                                 defaultCountries={countryId ? [countryId] : undefined}
                                 countriesHidden={isDefined(countryId)}
+                                defaultCrises={crisisId ? [crisisId] : undefined}
                             />
                         )}
                         {selectedTab === 'Figures' && (
@@ -243,6 +254,7 @@ function EntriesFiguresTable(props: EntriesFiguresTableProps) {
                                 defaultCountries={countryId ? [countryId] : undefined}
                                 eventsHidden={isDefined(eventId)}
                                 countriesHidden={isDefined(countryId)}
+                                defaultCrises={crisisId ? [crisisId] : undefined}
                             />
                         )}
                     </>

--- a/src/components/tables/EventsEntriesFiguresTable/index.tsx
+++ b/src/components/tables/EventsEntriesFiguresTable/index.tsx
@@ -348,20 +348,31 @@ function EventsEntriesFiguresTable(props: EventsEntriesFiguresTableProps) {
                                 countriesSelectionDisabled={!!countryId}
                                 reviewStatusSelectionDisabled={false}
                                 crisisSelectionDisabled={!!crisisId}
+                                defaultCountries={countryId ? [countryId] : undefined}
+                                defaultEvents={eventId ? [eventId] : undefined}
+                                defaultCrises={crisisId ? [crisisId] : undefined}
                             />
                         )}
                         {selectedTab === 'Entries' && (
                             <EntriesFilter
                                 onFilterChange={onFilterChange}
+                                reviewStatusHidden={false}
+                                defaultEvents={eventId ? [eventId] : undefined}
                                 defaultCountries={countryId ? [countryId] : undefined}
+                                eventsHidden={isDefined(eventId)}
                                 countriesHidden={isDefined(countryId)}
+                                defaultCrises={crisisId ? [crisisId] : undefined}
                             />
                         )}
                         {selectedTab === 'Figures' && (
                             <EntriesFilter
                                 onFilterChange={onFilterChange}
+                                reviewStatusHidden={false}
+                                defaultEvents={eventId ? [eventId] : undefined}
                                 defaultCountries={countryId ? [countryId] : undefined}
+                                eventsHidden={isDefined(eventId)}
                                 countriesHidden={isDefined(countryId)}
+                                defaultCrises={crisisId ? [crisisId] : undefined}
                             />
                         )}
                     </>

--- a/src/components/tables/EventsTable/index.tsx
+++ b/src/components/tables/EventsTable/index.tsx
@@ -7,7 +7,6 @@ import {
 import EventsFilter from '#components/rawTables/EventsTable/EventsFilter';
 import useEventTable from '#components/rawTables/EventsTable';
 import Container from '#components/Container';
-import { CrisisOption } from '#components/selections/CrisisSelectInput';
 import {
     EventListQueryVariables,
     Qa_Rule_Type as QaRuleType,
@@ -42,7 +41,6 @@ const defaultSorting = {
 interface EventsProps {
     className?: string;
     title?: string;
-    crisis?: CrisisOption | null;
 
     reviewStatus?: string[] | null
     assignee?: string | null;
@@ -52,7 +50,6 @@ interface EventsProps {
 function EventsTable(props: EventsProps) {
     const {
         className,
-        crisis,
         qaMode,
         title,
         assignee,
@@ -115,8 +112,6 @@ function EventsTable(props: EventsProps) {
         ? qaMode === 'IGNORE_QA'
         : undefined;
 
-    const crisisId = crisis?.id;
-
     const [
         eventQueryFilters,
         setEventQueryFilters,
@@ -153,9 +148,6 @@ function EventsTable(props: EventsProps) {
             assignees: assignee
                 ? [assignee]
                 : eventQueryFilters?.assignees,
-            crisisByIds: crisisId
-                ? [crisisId]
-                : eventQueryFilters?.crisisByIds,
         }),
         [
             ordering,
@@ -166,7 +158,6 @@ function EventsTable(props: EventsProps) {
             reviewStatus,
             ignoreQa,
             eventQueryFilters,
-            crisisId,
         ],
     );
 
@@ -177,7 +168,6 @@ function EventsTable(props: EventsProps) {
         pager: eventsPager,
     } = useEventTable({
         className: styles.table,
-        crisis,
         qaMode,
         filters: eventsVariables,
         page,
@@ -202,7 +192,7 @@ function EventsTable(props: EventsProps) {
             description={(
                 <EventsFilter
                     onFilterChange={onFilterChange}
-                    crisisSelectionDisabled={!!crisisId}
+                    crisisSelectionDisabled={false}
                     reviewStatusSelectionDisabled={!!reviewStatus}
                     createdBySelectionDisabled={false}
                     countriesSelectionDisabled={false}

--- a/src/components/tables/ReportsTable/ReportForm/index.tsx
+++ b/src/components/tables/ReportsTable/ReportForm/index.tsx
@@ -723,7 +723,7 @@ function ReportForm(props: ReportFormProps) {
                             onChange={onValueChange}
                             disabled={disabled}
                             onOptionsChange={setCrises}
-                            countries={value.filterFigureCountries}
+                            // countries={value.filterFigureCountries}
                         />
                         <EventMultiSelectInput
                             label="Events"


### PR DESCRIPTION
Addresses https://github.com/idmc-labs/helix2.0-meta/issues/932
Depends on https://github.com/idmc-labs/helix-server/pull/531

## Changes

- ReportForm: Remove filtering of crisis by countries
- AdvancedEntriesFilter: Remove filtering of crisis by countries
- EntriesFilter: Add defaultCrises prop
- EntriesFilter: Add crisis and event filter to country input
- EntriesFilter: Add crisis and country filter to event input
- EventFilter: Add defaultEvents, defaultCrises prop
- EventFilter: Add country filter to crisis input
- EventFilter: Add crisis and event filter to country input
- CountryMultiSelectInput:  Add defaultEvents and defaultCrises filter
- CountrySelectInput:  Add defaultEvents and defaultCrises filter
- CrisisSelectInput:  Add defaultCountries filter
- EventListInput:  Add defaultCrises and defaultCountries filter
- EventSelectInput:  Add defaultCrises and defaultCountries filter
- EventMultiSelectInput:  Add defaultCrises and defaultCountries filter
- CrisisTable: Remove crisis filter
- EntriesFiguresTable: Add crisis fitler for entries
- EntriesFiguresTable: Add crisis fitler for figures
- EntriesFiguresTable: Add crisis on EntriesFilter
- EventsEntriesFiguresTable: Add crisis on EntriesFilter

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
