### PR TITLE
Update apollo to override networkError

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
         "@types/uuid": "^8.3.0",
         "apollo-link": "^1.2.14",
         "apollo-link-batch-http": "^1.2.14",
+        "apollo-link-error": "^1.1.13",
         "apollo-link-rest": "^0.8.0-beta.0",
         "apollo-link-retry": "^2.2.16",
         "apollo-upload-client": "^14.1.3",

--- a/src/components/forms/EntryForm/FigureInput/index.tsx
+++ b/src/components/forms/EntryForm/FigureInput/index.tsx
@@ -509,11 +509,7 @@ function FigureInput(props: FigureInputProps) {
                     notifyGQLError(errors);
                 }
                 if (result) {
-                    // FIXME: we need to move this behavior to the parent
-                    setEvents((oldEvents) => unique([
-                        result.event,
-                        ...(oldEvents ?? []),
-                    ], (event) => event.id));
+                    setEvents([result.event]);
                     notify({
                         children: 'Figure approved successfully!',
                         variant: 'success',
@@ -545,11 +541,7 @@ function FigureInput(props: FigureInputProps) {
                     notifyGQLError(errors);
                 }
                 if (result) {
-                    // FIXME: we need to move this behavior to the parent
-                    setEvents((oldEvents) => unique([
-                        result.event,
-                        ...(oldEvents ?? []),
-                    ], (event) => event.id));
+                    setEvents([result.event]);
                     notify({
                         children: 'Figure unapproved successfully!',
                         variant: 'success',
@@ -581,11 +573,7 @@ function FigureInput(props: FigureInputProps) {
                     notifyGQLError(errors);
                 }
                 if (result) {
-                    // FIXME: we need to move this behavior to the parent
-                    setEvents((oldEvents) => unique([
-                        result.event,
-                        ...(oldEvents ?? []),
-                    ], (event) => event.id));
+                    setEvents([result.event]);
                     notify({
                         children: 'Figure re-request review successfully!',
                         variant: 'success',
@@ -912,8 +900,7 @@ function FigureInput(props: FigureInputProps) {
 
     const handleEventCreate = useCallback(
         (newEvent: EventListOption) => {
-            // FIXME: we need to move this behavior to the parent
-            setEvents((oldEvents) => [...(oldEvents ?? []), newEvent]);
+            setEvents([newEvent]);
             handleEventChange(newEvent.id, 'event', newEvent);
             hideEventModal();
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,7 +4965,7 @@ apollo-link-context@^1.0.9:
     apollo-link "^1.2.14"
     tslib "^1.9.3"
 
-apollo-link-error@^1.1.1:
+apollo-link-error@^1.1.1, apollo-link-error@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.13.tgz#c1a1bb876ffe380802c8df0506a32c33aad284cd"
   integrity sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==


### PR DESCRIPTION
- Override network error if we have graphql errors
- Fix event options issue after failure on entry form
- Move non field errors to the top

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
