### PR TITLE
Use same path and loader for entry pages

### DIFF
--- a/src/Root/App/Multiplexer/index.tsx
+++ b/src/Root/App/Multiplexer/index.tsx
@@ -357,18 +357,13 @@ function Multiplexer(props: Props) {
                                         />
                                         <Route
                                             exact
-                                            path={routeSettings.entryEdit.path}
-                                            render={routeSettings.entryEdit.load}
-                                        />
-                                        <Route
-                                            exact
-                                            path={routeSettings.entryView.path}
-                                            render={routeSettings.entryView.load}
-                                        />
-                                        <Route
-                                            exact
-                                            path={routeSettings.newEntryFromParkedItem.path}
-                                            render={routeSettings.newEntryFromParkedItem.load}
+                                            path={[
+                                                routeSettings.newEntry.path,
+                                                routeSettings.newEntryFromParkedItem.path,
+                                                routeSettings.entryEdit.path,
+                                                routeSettings.entryView.path,
+                                            ]}
+                                            render={routeSettings.newEntry.load}
                                         />
                                         <Route
                                             exact
@@ -424,11 +419,6 @@ function Multiplexer(props: Props) {
                                             exact
                                             path={routeSettings.qaDashboard.path}
                                             render={routeSettings.qaDashboard.load}
-                                        />
-                                        <Route
-                                            exact
-                                            path={routeSettings.newEntry.path}
-                                            render={routeSettings.newEntry.load}
                                         />
                                         <Route
                                             exact

--- a/src/components/forms/EntryForm/schema.ts
+++ b/src/components/forms/EntryForm/schema.ts
@@ -204,7 +204,7 @@ const figure: Figure = {
             unit: [requiredCondition],
             figureCause: [requiredCondition],
             event: [requiredCondition],
-            entry: [requiredCondition],
+            entry: [],
             sources: [requiredListCondition, arrayCondition],
             geoLocations,
 
@@ -357,6 +357,7 @@ type EntryFields = ReturnType<Entry['fields']>;
 
 export const schema: Schema<PartialFormValues> = {
     fields: (): EntryFields => ({
+        id: [],
         details,
         analysis: analysisLogic,
         figures,

--- a/src/components/forms/EntryForm/types.ts
+++ b/src/components/forms/EntryForm/types.ts
@@ -27,6 +27,7 @@ export type AnalysisFormProps = PurgeNull<Pick<FormType, 'idmcAnalysis'>>;
 export type DetailsFormProps = PurgeNull<Pick<FormType, 'articleTitle' | 'publishDate' | 'publishers' | 'url' | 'document' | 'documentUrl' | 'preview' | 'isConfidential' | 'associatedParkedItem'>>;
 
 export type FormValues = PurgeNull<{
+    id: string | undefined;
     figures: FigureFormProps[];
     analysis: AnalysisFormProps;
     details: DetailsFormProps;

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -26,6 +26,71 @@ export function wrap<T extends string, K extends { className?: string }>(
     };
 }
 
+const entryRoute = wrap({
+    path: '?',
+    title: (key) => {
+        if (key === '/entries/:entryId(\\d+)/') {
+            return 'View Entry';
+        }
+        if (key === '/entries/new/') {
+            return 'New Entry';
+        }
+        if (key === '/entries/new-from-parked-item/:parkedItemId(\\d+)/') {
+            return 'New Entry from Parking Lot';
+        }
+        if (key === '/entries/:entryId(\\d+)/edit/') {
+            return 'Edit Entry';
+        }
+        return '???';
+    },
+    navbarVisibility: true,
+    component: lazy(() => import('../views/Entry')),
+    componentProps: (key) => {
+        if (key === '/entries/:entryId(\\d+)/') {
+            return {
+                className: styles.view,
+                mode: 'view' as const,
+            };
+        }
+        return {
+            className: styles.view,
+            mode: 'edit' as const,
+        };
+    },
+    visibility: 'is-authenticated',
+    checkPermissions: (permissions, key) => {
+        if (key === '/entries/:entryId(\\d+)/') {
+            return true;
+        }
+        if (key === '/entries/new/') {
+            return permissions.entry?.add;
+        }
+        if (key === '/entries/new-from-parked-item/:parkedItemId(\\d+)/') {
+            return permissions.entry?.add;
+        }
+        if (key === '/entries/:entryId(\\d+)/edit/') {
+            return permissions.entry?.change;
+        }
+        return false;
+    },
+    shouldPageDismount: (prevRoute, newRoute) => {
+        if (
+            newRoute.path === '/entries/new/'
+            && prevRoute.path !== '/entries/new/'
+        ) {
+            return true;
+        }
+        if (
+            newRoute.path === '/entries/:entryId(\\d+)/edit/'
+            && prevRoute.path === '/entries/:entryId(\\d+)/edit/'
+            && JSON.stringify(newRoute.params) !== JSON.stringify(prevRoute.params)
+        ) {
+            return true;
+        }
+        return false;
+    },
+});
+
 const routeSettings = {
     dashboard: wrap({
         path: '/',
@@ -158,53 +223,22 @@ const routeSettings = {
         },
         visibility: 'is-authenticated',
     }),
-    newEntry: wrap({
+    newEntry: {
+        ...entryRoute,
         path: '/entries/new/',
-        title: 'New Entry',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: {
-            className: styles.view,
-            mode: 'edit',
-        },
-        visibility: 'is-authenticated',
-        checkPermissions: (permissions) => permissions.entry?.add,
-    }),
-    entryEdit: wrap({
-        path: '/entries/:entryId(\\d+)/edit/',
-        title: 'Edit Entry',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: {
-            className: styles.view,
-            mode: 'edit',
-        },
-        visibility: 'is-authenticated',
-        checkPermissions: (permissions) => permissions.entry?.change,
-    }),
-    newEntryFromParkedItem: wrap({
+    },
+    newEntryFromParkedItem: {
+        ...entryRoute,
         path: '/entries/new-from-parked-item/:parkedItemId(\\d+)/',
-        title: 'New Entry from Parking Lot',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: {
-            className: styles.view,
-            mode: 'edit',
-        },
-        visibility: 'is-authenticated',
-        checkPermissions: (permissions) => permissions.entry?.add,
-    }),
-    entryView: wrap({
+    },
+    entryEdit: {
+        ...entryRoute,
+        path: '/entries/:entryId(\\d+)/edit/',
+    },
+    entryView: {
+        ...entryRoute,
         path: '/entries/:entryId(\\d+)/',
-        title: 'View Entry',
-        navbarVisibility: true,
-        component: lazy(() => import('../views/Entry')),
-        componentProps: {
-            className: styles.view,
-            mode: 'view',
-        },
-        visibility: 'is-authenticated',
-    }),
+    },
     reports: wrap({
         path: '/reports/',
         title: 'Reports',

--- a/src/hooks/useBulkSaveRegister.ts
+++ b/src/hooks/useBulkSaveRegister.ts
@@ -66,6 +66,13 @@ function useBulkSaveRegister<
         [defaultState],
     );
 
+    const updateState = useCallback(
+        (updaterFunction: (oldValue: Entries['state']) => Entries['state']) => {
+            entriesRef.current.state = updaterFunction(entriesRef.current.state);
+        },
+        [],
+    );
+
     const end = useCallback(
         () => {
             const state = entriesRef.current;
@@ -134,8 +141,9 @@ function useBulkSaveRegister<
     return {
         pending,
         start,
-        updateResponses,
         end,
+        updateState,
+        updateResponses,
         getNextRequests,
     };
 }

--- a/src/hooks/useRouteMatching.ts
+++ b/src/hooks/useRouteMatching.ts
@@ -32,7 +32,7 @@ function useRouteMatching(route: RouteData, attrs?: Attrs) {
 
     if (
         (visibility === 'is-authenticated' && !authenticated)
-        || (checkPermissions && (!user?.permissions || !checkPermissions(user.permissions)))
+        || (checkPermissions && (!user?.permissions || !checkPermissions(user.permissions, path)))
     ) {
         return undefined;
     }


### PR DESCRIPTION
## Changes

- newEntry, newEntryFromParkedItem, entryEdit and entryView all use the same configuration
- Update View component to support dynamic properties
- Expose function to update state of useBulkSaveRegister
- Update createEntry onCompleted function to handle responses (as the page will not be dismounted)
- Enable adding figures even if entry is not saved
- Add shouldPageDismount on View to force dismount pages

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [ ] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
